### PR TITLE
docs(README): align Import Leads columns with UI (Prospect Name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Schema is applied from [`sql/schema.sql`](sql/schema.sql) (idempotent). See [doc
 
 1. Open **Import Leads**
 2. Paste from Excel, Sheets, or CSV — or upload `.csv` / `.xlsx`
-3. Columns: `Company · Prospect · Job title · Email · Phone · Location · Employees · Industry`
+3. Columns: `Company · Prospect Name · Job Title · Email · Phone · Location · Employees · Industry`
 4. Import — companies create/update; duplicate emails skip
 
 Samples in the UI use synthetic `@*.example` data only.


### PR DESCRIPTION
# docs(README): align Import Leads columns with UI (Prospect Name)

## Summary

The "Import leads" section of `README.md` listed the paste columns as
`Company · Prospect · Job title · ...`, but the Import Leads UI and its
parser actually label and accept `Prospect Name` and `Job Title`. This PR
aligns the README column list with the UI so contributors/users pasting
leads have the right header names. Fixes #21.

## Changes

- `README.md` (Import leads section): `Prospect` -> `Prospect Name` and
  `Job title` -> `Job Title` in the columns line.

## Testing

Docs-only change to a single line in `README.md`; no build/runtime code is
affected, so there is no test surface to exercise. Verified the target
labels against the existing code (not modified here):

- `src/components/ImportLeads.tsx:227` renders the field label
  "Prospect name *"; lines 17 and 182 use the header
  `Company, Prospect Name, Job Title, Email, Phone, Location, Employees, Industry`.
- `src/lib/importProspects.ts:5` documents the same column order
  `Company | Prospect Name | Job Title | Email | ...`, and the CSV template
  on line 170 uses `Company,Prospect Name,Job Title,...`.

No `npm ci` / `npm run ci` run is applicable to a one-line markdown fix.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
