### PR TITLE
fix: Playwright TS errors + run CI on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
+# Runs on every PR (any target branch) and on pushes to main.
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   unit:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ const FORCE_FROM_FILE = new Set([
 function loadTestingEnv(): Record<string, string> {
   const env: Record<string, string> = {}
   for (const [k, v] of Object.entries(process.env)) {
-    if (v !== undefined) env[k] = v
+    if (typeof v === 'string') env[k] = v
   }
 
   const path = resolve(process.cwd(), 'testing/functional/.env.testing')

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,5 +19,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts", "server/**/*.ts", "api/**/*.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts", "server/**/*.ts", "api/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- Fix IDE/TypeScript errors in `playwright.config.ts` (`process`, `node:fs`, `node:path`, env typing) by including the file in `tsconfig.node.json` (so `@types/node` applies).
- Broaden CI triggers so Actions run on **every pull request** (any target branch), plus `workflow_dispatch`.

## Test plan
- [x] `npx tsc -p tsconfig.node.json` clean
- [x] `npm run build` passes
- [ ] Confirm Problems panel clears for `playwright.config.ts`
- [ ] Confirm CI jobs (unit / API / e2e) run on this PR


Made with [Cursor](https://cursor.com)