### PR TITLE
Close modal on Escape and add dialog ARIA

### DIFF
--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useId } from 'react'
 import type { ReactNode } from 'react'
 
 interface ModalProps {
@@ -9,6 +10,17 @@ interface ModalProps {
 }
 
 export function Modal({ open, title, onClose, children, wide }: ModalProps) {
+  const titleId = useId()
+
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open, onClose])
+
   if (!open) return null
 
   return (
@@ -20,12 +32,18 @@ export function Modal({ open, title, onClose, children, wide }: ModalProps) {
         onClick={onClose}
       />
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         className={`relative z-10 my-0 w-full rounded-none border border-[var(--color-line)] bg-[var(--color-panel)] sm:my-4 ${
           wide ? 'max-w-3xl' : 'max-w-xl'
         }`}
       >
         <div className="flex items-center justify-between border-b border-[var(--color-line)] px-4 py-3 sm:px-5 sm:py-4">
-          <h2 className="font-[family-name:var(--font-display)] text-xl text-stone-900 sm:text-2xl">
+          <h2
+            id={titleId}
+            className="font-[family-name:var(--font-display)] text-xl text-stone-900 sm:text-2xl"
+          >
             {title}
           </h2>
           <button

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId } from 'react'
+import { useEffect, useId, useRef } from 'react'
 import type { ReactNode } from 'react'
 
 interface ModalProps {
@@ -11,15 +11,17 @@ interface ModalProps {
 
 export function Modal({ open, title, onClose, children, wide }: ModalProps) {
   const titleId = useId()
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
 
   useEffect(() => {
     if (!open) return
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') onCloseRef.current()
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [open, onClose])
+  }, [open])
 
   if (!open) return null
 

--- a/testing/e2e/modal-a11y.spec.ts
+++ b/testing/e2e/modal-a11y.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from '@playwright/test'
+import { loginAsFounder, navTo } from './helpers'
+
+/**
+ * Issue #13 — the shared Modal (src/components/ui.tsx) must be an accessible
+ * dialog: role="dialog" + aria-modal="true", an accessible name taken from its
+ * title, Escape-to-close (and a harmless no-op when nothing is open), plus
+ * dismissal via the Close button and via the backdrop.
+ *
+ * We drive the real "Add company" modal (Sales Pipeline → "+ Add company").
+ * No test submits the form, so nothing is persisted — every modal is discarded.
+ */
+
+/** Open the "Add company" modal and return its dialog locator. */
+async function openAddCompanyModal(page: Page) {
+  await page.getByRole('button', { name: '+ Add company' }).click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  return dialog
+}
+
+test.describe('Modal accessibility (issue #13)', () => {
+  test('modal is a dialog with aria-modal and an accessible name from its title', async ({
+    page,
+  }) => {
+    await loginAsFounder(page)
+    await navTo(page, 'Sales Pipeline')
+
+    const dialog = await openAddCompanyModal(page)
+    await expect(dialog).toHaveAttribute('aria-modal', 'true')
+    // The accessible name is wired to the modal's title ("Add company").
+    await expect(dialog).toHaveAccessibleName('Add company')
+  })
+
+  test('Escape closes the dialog', async ({ page }) => {
+    await loginAsFounder(page)
+    await navTo(page, 'Sales Pipeline')
+
+    await openAddCompanyModal(page)
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+  })
+
+  test('Escape with no dialog open is a no-op and the page stays usable', async ({ page }) => {
+    await loginAsFounder(page)
+    await navTo(page, 'Sales Pipeline')
+
+    // Nothing is open to begin with.
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+    // Escape must not throw or wedge the app when there is no open modal.
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+
+    // The page is still interactive: the modal can still be opened afterwards.
+    const dialog = await openAddCompanyModal(page)
+    await expect(dialog).toBeVisible()
+  })
+
+  test('the Close button dismisses the dialog', async ({ page }) => {
+    await loginAsFounder(page)
+    await navTo(page, 'Sales Pipeline')
+
+    await openAddCompanyModal(page)
+    await page.getByRole('button', { name: 'Close', exact: true }).click()
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+  })
+
+  test('clicking the backdrop dismisses the dialog', async ({ page }) => {
+    await loginAsFounder(page)
+    await navTo(page, 'Sales Pipeline')
+
+    await openAddCompanyModal(page)
+    // The backdrop is a full-screen button rendered behind the centered panel;
+    // click a top-left corner the panel does not cover so the click lands on it.
+    await page
+      .getByRole('button', { name: 'Dismiss dialog' })
+      .click({ position: { x: 5, y: 5 } })
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+  })
+})


### PR DESCRIPTION
Fixes #13

Adds Escape-to-close and dialog ARIA to the shared `Modal` in `src/components/ui.tsx`:

- Pressing Escape while the modal is open calls `onClose` (document keydown listener, active only while open, cleaned up on close/unmount)
- Dialog container gets `role="dialog"` and `aria-modal="true"`
- Title is associated via `aria-labelledby` using a shared `useId`
- Backdrop dismiss and the Close button are unchanged
- Focus trap left out per the issue's scope

Tested per the issue: `tsc -b`, lint, unit tests, and build all pass, and verified in the running app (demo account) that Escape, Close, and backdrop click each dismiss the edit-contact modal, with `role="dialog"`/`aria-modal="true"` present in the DOM.