### PR TITLE
Champion contact badges, short trail, and auto-move on Pipeline kanban

### DIFF
--- a/server/activity.ts
+++ b/server/activity.ts
@@ -1,4 +1,5 @@
 import { pool } from './db.js'
+import type { Pool, PoolClient } from 'pg'
 
 export const IDLE_MS = 45 * 60 * 1000
 export const ACTIVITY_TZ = 'Asia/Kolkata'
@@ -49,9 +50,18 @@ export function isConnectedStatus(status: string): boolean {
   return CONNECTED_STATUSES.has(status)
 }
 
-export async function logActivity(input: LogActivityInput): Promise<void> {
+/**
+ * A pg executor for an activity insert: the shared `pool` (default, autocommit)
+ * or a `PoolClient` bound to an open transaction.
+ */
+export type ActivityExecutor = Pool | PoolClient
+
+export async function logActivity(
+  input: LogActivityInput,
+  executor: ActivityExecutor = pool,
+): Promise<void> {
   try {
-    await pool.query(
+    await executor.query(
       `
       INSERT INTO activity_events (
         user_id, session_id, event_type, entity_type, entity_id, summary, payload, created_at
@@ -70,6 +80,12 @@ export async function logActivity(input: LogActivityInput): Promise<void> {
     )
   } catch (e) {
     console.error('[activity] log failed', e)
+    // On the shared pool an activity insert stays best-effort (non-fatal), as
+    // before. Inside a transaction it is part of the atomic unit — and a pg
+    // transaction is poisoned the moment any statement errors (every later
+    // command fails until ROLLBACK), so the failure MUST surface to let the
+    // caller roll back instead of committing partial state.
+    if (executor !== pool) throw e
   }
 }
 

--- a/server/activity.ts
+++ b/server/activity.ts
@@ -231,7 +231,7 @@ export function accumulateCallMetrics(
     if (to === 'Rejected') metrics.notInterested += 1
   }
   if (eventType === 'contact.follow_up_set') metrics.followUps += 1
-  if (eventType === 'company.stage_changed') {
+  if (eventType === 'company.stage_changed' && payload.source !== 'champion_contact') {
     const to = String(payload.to ?? '')
     if (to === 'Demo Scheduled') metrics.demo += 1
     if (to === 'Closed Won') metrics.converted += 1

--- a/server/app.ts
+++ b/server/app.ts
@@ -695,111 +695,148 @@ app.patch('/api/contacts/:id', requireAuth, async (req, res) => {
   }
 
   const { assignments, idParam, values } = update.finalize(id)
-  const { rows } = await pool.query(
-    `UPDATE contacts SET ${assignments} WHERE id = $${idParam} RETURNING *`,
-    values,
-  )
-  if (!rows[0]) {
-    res.status(404).json({ error: 'Contact not found' })
-    return
-  }
 
-  const contact = rows[0]
-  if (b.champion === true && contact.company_id) {
-    await pool.query('UPDATE companies SET primary_contact_id = $1 WHERE id = $2', [
-      contact.id,
-      contact.company_id,
-    ])
-  }
+  // Atomic unit: the contact update, the optional champion→company writes, the
+  // stage auto-move, and every related activity insert must all commit together
+  // or not at all — otherwise a failed stage write leaves the contact advanced
+  // while the board stays stale. Mirror the import handler's transaction shape.
+  const client = await pool.connect()
+  try {
+    await client.query('BEGIN')
 
-  const name = String(contact.contact_name)
-  const sid = req.user!.sid
-  const uid = req.user!.sub
-  if (b.contactStatus !== undefined && b.contactStatus !== before.contact_status) {
-    await logActivity({
-      userId: uid,
-      sessionId: sid,
-      eventType: 'contact.status_changed',
-      entityType: 'contact',
-      entityId: String(id),
-      summary: `Changed status → ${b.contactStatus}`,
-      payload: { from: before.contact_status, to: b.contactStatus, name },
-    })
-  }
-  if (b.nextFollowUp !== undefined && b.nextFollowUp !== before.next_follow_up) {
-    await logActivity({
-      userId: uid,
-      sessionId: sid,
-      eventType: 'contact.follow_up_set',
-      entityType: 'contact',
-      entityId: String(id),
-      summary: `Follow-up added for ${name}`,
-      payload: { nextFollowUp: b.nextFollowUp, name },
-    })
-  }
-  if (b.notes !== undefined && b.notes !== before.notes) {
-    await logActivity({
-      userId: uid,
-      sessionId: sid,
-      eventType: 'contact.note_added',
-      entityType: 'contact',
-      entityId: String(id),
-      summary: `Added note on ${name}`,
-      payload: { name },
-    })
-  }
-  if (
-    (b.contactName !== undefined ||
-      b.phone !== undefined ||
-      b.email !== undefined ||
-      b.role !== undefined ||
-      b.companyId !== undefined) &&
-    b.contactStatus === undefined
-  ) {
-    await logActivity({
-      userId: uid,
-      sessionId: sid,
-      eventType: 'contact.updated',
-      entityType: 'contact',
-      entityId: String(id),
-      summary: `Updated ${name}`,
-      payload: { name },
-    })
-  }
-
-  if (
-    b.contactStatus !== undefined &&
-    b.contactStatus !== before.contact_status &&
-    contact.champion &&
-    contact.company_id
-  ) {
-    const { rows: companyRows } = await pool.query(
-      'SELECT stage, company_name FROM companies WHERE id = $1',
-      [contact.company_id],
+    const { rows } = await client.query(
+      `UPDATE contacts SET ${assignments} WHERE id = $${idParam} RETURNING *`,
+      values,
     )
-    const company = companyRows[0]
-    if (company) {
-      const target = resolveAutoMoveStage(company.stage, contact.contact_status)
-      if (target) {
-        await pool.query('UPDATE companies SET stage = $1, updated_at = now() WHERE id = $2', [
-          target,
-          contact.company_id,
-        ])
-        const companyName = String(company.company_name)
-        await logActivity({
+    if (!rows[0]) {
+      await client.query('ROLLBACK')
+      res.status(404).json({ error: 'Contact not found' })
+      return
+    }
+
+    const contact = rows[0]
+    // Set when a champion status change auto-advances the company; null otherwise.
+    // Consumed by the web client to reconcile the Kanban board — keep this name.
+    let movedCompanyStage: string | null = null
+
+    if (b.champion === true && contact.company_id) {
+      await client.query('UPDATE companies SET primary_contact_id = $1 WHERE id = $2', [
+        contact.id,
+        contact.company_id,
+      ])
+    }
+
+    const name = String(contact.contact_name)
+    const sid = req.user!.sid
+    const uid = req.user!.sub
+    if (b.contactStatus !== undefined && b.contactStatus !== before.contact_status) {
+      await logActivity(
+        {
           userId: uid,
           sessionId: sid,
-          eventType: 'company.stage_changed',
-          entityType: 'company',
-          entityId: String(contact.company_id),
-          summary: `Stage → ${target} (${companyName})`,
-          payload: { from: company.stage, to: target, name: companyName, source: 'champion_contact' },
-        })
+          eventType: 'contact.status_changed',
+          entityType: 'contact',
+          entityId: String(id),
+          summary: `Changed status → ${b.contactStatus}`,
+          payload: { from: before.contact_status, to: b.contactStatus, name },
+        },
+        client,
+      )
+    }
+    if (b.nextFollowUp !== undefined && b.nextFollowUp !== before.next_follow_up) {
+      await logActivity(
+        {
+          userId: uid,
+          sessionId: sid,
+          eventType: 'contact.follow_up_set',
+          entityType: 'contact',
+          entityId: String(id),
+          summary: `Follow-up added for ${name}`,
+          payload: { nextFollowUp: b.nextFollowUp, name },
+        },
+        client,
+      )
+    }
+    if (b.notes !== undefined && b.notes !== before.notes) {
+      await logActivity(
+        {
+          userId: uid,
+          sessionId: sid,
+          eventType: 'contact.note_added',
+          entityType: 'contact',
+          entityId: String(id),
+          summary: `Added note on ${name}`,
+          payload: { name },
+        },
+        client,
+      )
+    }
+    if (
+      (b.contactName !== undefined ||
+        b.phone !== undefined ||
+        b.email !== undefined ||
+        b.role !== undefined ||
+        b.companyId !== undefined) &&
+      b.contactStatus === undefined
+    ) {
+      await logActivity(
+        {
+          userId: uid,
+          sessionId: sid,
+          eventType: 'contact.updated',
+          entityType: 'contact',
+          entityId: String(id),
+          summary: `Updated ${name}`,
+          payload: { name },
+        },
+        client,
+      )
+    }
+
+    if (
+      b.contactStatus !== undefined &&
+      b.contactStatus !== before.contact_status &&
+      contact.champion &&
+      contact.company_id
+    ) {
+      const { rows: companyRows } = await client.query(
+        'SELECT stage, company_name FROM companies WHERE id = $1',
+        [contact.company_id],
+      )
+      const company = companyRows[0]
+      if (company) {
+        const target = resolveAutoMoveStage(company.stage, contact.contact_status)
+        if (target) {
+          await client.query('UPDATE companies SET stage = $1, updated_at = now() WHERE id = $2', [
+            target,
+            contact.company_id,
+          ])
+          movedCompanyStage = target
+          const companyName = String(company.company_name)
+          await logActivity(
+            {
+              userId: uid,
+              sessionId: sid,
+              eventType: 'company.stage_changed',
+              entityType: 'company',
+              entityId: String(contact.company_id),
+              summary: `Stage → ${target} (${companyName})`,
+              payload: { from: company.stage, to: target, name: companyName, source: 'champion_contact' },
+            },
+            client,
+          )
+        }
       }
     }
-  }
 
-  res.json(mapContact(contact))
+    await client.query('COMMIT')
+    res.json({ ...mapContact(contact), movedCompanyStage })
+  } catch (e) {
+    await client.query('ROLLBACK')
+    throw e
+  } finally {
+    client.release()
+  }
 })
 
 app.delete('/api/contacts/:id', requireAuth, requireAdmin, async (req, res) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -28,6 +28,7 @@ import {
   touchSession,
 } from './activity.js'
 import { CONTACT_STATUSES, STAGES } from '../src/types.js'
+import { resolveAutoMoveStage } from '../src/lib/championSync.js'
 
 const app = express()
 app.use(
@@ -764,6 +765,38 @@ app.patch('/api/contacts/:id', requireAuth, async (req, res) => {
       summary: `Updated ${name}`,
       payload: { name },
     })
+  }
+
+  if (
+    b.contactStatus !== undefined &&
+    b.contactStatus !== before.contact_status &&
+    contact.champion &&
+    contact.company_id
+  ) {
+    const { rows: companyRows } = await pool.query(
+      'SELECT stage, company_name FROM companies WHERE id = $1',
+      [contact.company_id],
+    )
+    const company = companyRows[0]
+    if (company) {
+      const target = resolveAutoMoveStage(company.stage, contact.contact_status)
+      if (target) {
+        await pool.query('UPDATE companies SET stage = $1, updated_at = now() WHERE id = $2', [
+          target,
+          contact.company_id,
+        ])
+        const companyName = String(company.company_name)
+        await logActivity({
+          userId: uid,
+          sessionId: sid,
+          eventType: 'company.stage_changed',
+          entityType: 'company',
+          entityId: String(contact.company_id),
+          summary: `Stage → ${target} (${companyName})`,
+          payload: { from: company.stage, to: target, name: companyName, source: 'champion_contact' },
+        })
+      }
+    }
   }
 
   res.json(mapContact(contact))

--- a/src/components/Pipeline.tsx
+++ b/src/components/Pipeline.tsx
@@ -12,7 +12,7 @@ import {
   type DragStartEvent,
 } from '@dnd-kit/core'
 import { useMemo, useState } from 'react'
-import type { Company, PipelineView, Stage } from '../types'
+import type { Company, Contact, PipelineView, Stage } from '../types'
 import { STAGES } from '../types'
 import type { CrmStore } from '../hooks/useCrmStore'
 import {
@@ -20,7 +20,9 @@ import {
   filterCompanies,
   intentColor,
   stageAccent,
+  todayIso,
 } from '../lib/views'
+import { buildCardBadges, buildChampionTrail, findChampion } from '../lib/championCard'
 import { logViewEvent } from '../lib/activity'
 import { CompanyForm } from './CompanyForm'
 import { Modal, btnPrimary } from './ui'
@@ -40,17 +42,24 @@ function resolveDropStage(overId: string | number, companies: Company[]): Stage 
 
 function CompanyCard({
   company,
-  primaryName,
+  contacts,
+  today,
   dragging,
   onOpen,
 }: {
   company: Company
-  primaryName?: string
+  contacts: Contact[]
+  today: string
   dragging?: boolean
   onOpen?: () => void
 }) {
+  const badges = buildCardBadges(company, contacts, today)
+  const trail = buildChampionTrail(findChampion(contacts, company.id))
+
   return (
     <div
+      data-testid="company-card"
+      data-company-id={company.id}
       className={`rounded-none border border-[var(--color-line)] bg-white p-3 text-left transition hover:border-teal-600/40 ${
         dragging ? 'opacity-40' : ''
       }`}
@@ -66,8 +75,42 @@ function CompanyCard({
           <p className="mt-1 text-[11px] text-stone-500">
             {[company.industry, company.location].filter(Boolean).join(' · ') || '—'}
           </p>
-          {primaryName ? (
-            <p className="mt-2 text-[11px] font-medium text-teal-800">★ {primaryName}</p>
+          <div
+            data-testid="card-badges"
+            data-company-id={company.id}
+            className="mt-2 flex flex-wrap items-center gap-1"
+          >
+            <span className="rounded-none bg-stone-100 px-1.5 py-0.5 text-[10px] font-semibold text-stone-500">
+              {badges.contactCount} {badges.contactCount === 1 ? 'contact' : 'contacts'}
+            </span>
+            {badges.hasChampion ? (
+              <span
+                className="rounded-none bg-teal-100 px-1.5 py-0.5 text-[10px] font-semibold text-teal-800"
+                title="Has champion"
+              >
+                ★ Champion
+              </span>
+            ) : null}
+            {badges.followUpDueToday ? (
+              <span className="rounded-none bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-800">
+                Due today
+              </span>
+            ) : null}
+          </div>
+          {trail ? (
+            <div
+              data-testid="champion-trail"
+              data-company-id={company.id}
+              className="mt-2 space-y-0.5"
+            >
+              <p className="text-[11px] font-medium text-teal-800">{trail.header}</p>
+              {trail.note ? (
+                <p className="text-[10px] text-stone-500">{trail.note}</p>
+              ) : null}
+              {trail.followUp ? (
+                <p className="text-[10px] text-stone-400">{trail.followUp}</p>
+              ) : null}
+            </div>
           ) : null}
           {company.nextFollowUp ? (
             <p className="mt-1.5 text-[10px] text-stone-400">Follow-up {company.nextFollowUp}</p>
@@ -95,11 +138,13 @@ function CompanyCard({
 
 function DraggableCard({
   company,
-  primaryName,
+  contacts,
+  today,
   onOpen,
 }: {
   company: Company
-  primaryName?: string
+  contacts: Contact[]
+  today: string
   onOpen: () => void
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
@@ -121,7 +166,8 @@ function DraggableCard({
     >
       <CompanyCard
         company={company}
-        primaryName={primaryName}
+        contacts={contacts}
+        today={today}
         dragging={isDragging}
         onOpen={onOpen}
       />
@@ -133,11 +179,13 @@ function KanbanColumn({
   stage,
   companies,
   store,
+  today,
   onOpen,
 }: {
   stage: Stage
   companies: Company[]
   store: CrmStore
+  today: string
   onOpen: (c: Company) => void
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: stage, data: { type: 'column', stage } })
@@ -162,7 +210,8 @@ function KanbanColumn({
           <DraggableCard
             key={c.id}
             company={c}
-            primaryName={store.getContact(c.primaryContactId)?.contactName}
+            contacts={store.contacts}
+            today={today}
             onOpen={() => onOpen(c)}
           />
         ))}
@@ -208,6 +257,9 @@ export function Pipeline({ store }: PipelineProps) {
   const activeCompany = activeId
     ? store.companies.find((c) => c.id === activeId) ?? null
     : null
+
+  // Compute once per board render so every card's badges share one reference date.
+  const today = todayIso()
 
   const onDragStart = (e: DragStartEvent) => setActiveId(String(e.active.id))
 
@@ -274,6 +326,7 @@ export function Pipeline({ store }: PipelineProps) {
               stage={stage}
               companies={byStage.get(stage) ?? []}
               store={store}
+              today={today}
               onOpen={openCompany}
             />
           ))}
@@ -283,7 +336,8 @@ export function Pipeline({ store }: PipelineProps) {
             <div className="w-[min(72vw,16rem)] rotate-1 sm:w-64">
               <CompanyCard
                 company={activeCompany}
-                primaryName={store.getContact(activeCompany.primaryContactId)?.contactName}
+                contacts={store.contacts}
+                today={today}
               />
             </div>
           ) : null}

--- a/src/components/Pipeline.tsx
+++ b/src/components/Pipeline.tsx
@@ -15,14 +15,8 @@ import { useMemo, useState } from 'react'
 import type { Company, Contact, PipelineView, Stage } from '../types'
 import { STAGES } from '../types'
 import type { CrmStore } from '../hooks/useCrmStore'
-import {
-  PIPELINE_VIEWS,
-  filterCompanies,
-  intentColor,
-  stageAccent,
-  todayIso,
-} from '../lib/views'
-import { buildCardBadges, buildChampionTrail, findChampion } from '../lib/championCard'
+import { PIPELINE_VIEWS, filterCompanies, intentColor, stageAccent } from '../lib/views'
+import { buildCardBadges, buildChampionTrail, findChampion, istToday } from '../lib/championCard'
 import { logViewEvent } from '../lib/activity'
 import { CompanyForm } from './CompanyForm'
 import { Modal, btnPrimary } from './ui'
@@ -259,7 +253,9 @@ export function Pipeline({ store }: PipelineProps) {
     : null
 
   // Compute once per board render so every card's badges share one reference date.
-  const today = todayIso()
+  // Uses the Asia/Kolkata calendar day so the "Due today" badge and the champion
+  // follow-up line (also IST-formatted) agree near midnight.
+  const today = istToday()
 
   const onDragStart = (e: DragStartEvent) => setActiveId(String(e.active.id))
 

--- a/src/hooks/useCrmStore.ts
+++ b/src/hooks/useCrmStore.ts
@@ -5,6 +5,7 @@ import { canDeleteRecords } from '../types'
 import type {
   Company,
   Contact,
+  ContactStatus,
   ImportResult,
   ProspectRow,
   Stage,
@@ -35,6 +36,66 @@ const emptyMetrics: Metrics = {
   activeOpportunities: 0,
   closedWon: 0,
   closedLost: 0,
+}
+
+/**
+ * Response of `PATCH /api/contacts/:id`: the updated contact plus an optional
+ * champion auto-move annotation (issue #29). `movedCompanyStage` is the stage
+ * the server moved the owning company to, `null` when it applied no move, and
+ * absent on servers that predate the field.
+ */
+type UpdateContactResponse = Contact & { movedCompanyStage?: Stage | null }
+
+interface ChampionMoveInput {
+  contact: Pick<Contact, 'companyId' | 'champion' | 'contactStatus'>
+  prevContactStatus: ContactStatus | undefined
+  statusPatched: boolean
+  movedCompanyStage: Stage | null | undefined
+}
+
+/**
+ * Reconcile a company's Kanban stage after a champion's contact status changes
+ * (issue #29), returning the next `companies` array.
+ *
+ * The server is the source of truth: when the PATCH response carries a non-null
+ * `movedCompanyStage`, the owning company is moved to exactly that stage; when
+ * it is `null`, the server applied no move and the stage is left untouched.
+ * Local derivation from the (possibly stale) local stage is used only as a
+ * fallback when the field is absent — an older server that predates it.
+ */
+export function applyChampionAutoMove(
+  companies: Company[],
+  { contact, prevContactStatus, statusPatched, movedCompanyStage }: ChampionMoveInput,
+): Company[] {
+  // Newer server: trust the returned stage (string) or explicit no-move (null).
+  if (movedCompanyStage !== undefined) {
+    if (typeof movedCompanyStage === 'string' && contact.companyId) {
+      const companyId = contact.companyId
+      const stage = movedCompanyStage
+      return companies.map((c) => (c.id === companyId ? { ...c, stage } : c))
+    }
+    return companies
+  }
+
+  // Older server (field absent): derive the move from the local company stage.
+  if (
+    statusPatched &&
+    prevContactStatus !== undefined &&
+    prevContactStatus !== contact.contactStatus &&
+    contact.champion &&
+    contact.companyId
+  ) {
+    const company = companies.find((c) => c.id === contact.companyId)
+    if (company) {
+      const nextStage = resolveAutoMoveStage(company.stage, contact.contactStatus)
+      if (nextStage) {
+        return companies.map((c) =>
+          c.id === company.id ? { ...c, stage: nextStage } : c,
+        )
+      }
+    }
+  }
+  return companies
 }
 
 export function useCrmStore(enabled: boolean, userRole?: string) {
@@ -142,10 +203,10 @@ export function useCrmStore(enabled: boolean, userRole?: string) {
 
   const updateContact = useCallback(
     async (id: string, patch: Partial<Contact>) => {
-      const contact = await api<Contact>(`/api/contacts/${id}`, {
-        method: 'PATCH',
-        body: JSON.stringify(patch),
-      })
+      const { movedCompanyStage, ...contact } = await api<UpdateContactResponse>(
+        `/api/contacts/${id}`,
+        { method: 'PATCH', body: JSON.stringify(patch) },
+      )
       setState((s) => {
         const prev = s.contacts.find((t) => t.id === id)
         let companies = s.companies
@@ -155,24 +216,15 @@ export function useCrmStore(enabled: boolean, userRole?: string) {
             c.id === contact.companyId ? { ...c, primaryContactId: contact.id } : c,
           )
         }
-        // Mirror the server's champion auto-move (issue #29) so the board updates without a refetch.
-        if (
-          patch.contactStatus !== undefined &&
-          prev &&
-          prev.contactStatus !== contact.contactStatus &&
-          contact.champion &&
-          contact.companyId
-        ) {
-          const company = companies.find((c) => c.id === contact.companyId)
-          if (company) {
-            const nextStage = resolveAutoMoveStage(company.stage, contact.contactStatus)
-            if (nextStage) {
-              companies = companies.map((c) =>
-                c.id === company.id ? { ...c, stage: nextStage } : c,
-              )
-            }
-          }
-        }
+        // Mirror the server's champion auto-move (issue #29) so the board updates
+        // without a refetch, preferring the server-returned stage as the source of
+        // truth (local derivation stays only as a fallback for older servers).
+        companies = applyChampionAutoMove(companies, {
+          contact,
+          prevContactStatus: prev?.contactStatus,
+          statusPatched: patch.contactStatus !== undefined,
+          movedCompanyStage,
+        })
         return { companies, contacts }
       })
       await refreshMetrics()

--- a/src/hooks/useCrmStore.ts
+++ b/src/hooks/useCrmStore.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { api } from '../lib/api'
+import { resolveAutoMoveStage } from '../lib/championSync'
 import { canDeleteRecords } from '../types'
 import type {
   Company,
@@ -146,12 +147,31 @@ export function useCrmStore(enabled: boolean, userRole?: string) {
         body: JSON.stringify(patch),
       })
       setState((s) => {
+        const prev = s.contacts.find((t) => t.id === id)
         let companies = s.companies
         const contacts = s.contacts.map((t) => (t.id === id ? contact : t))
         if (patch.champion === true && contact.companyId) {
           companies = companies.map((c) =>
             c.id === contact.companyId ? { ...c, primaryContactId: contact.id } : c,
           )
+        }
+        // Mirror the server's champion auto-move (issue #29) so the board updates without a refetch.
+        if (
+          patch.contactStatus !== undefined &&
+          prev &&
+          prev.contactStatus !== contact.contactStatus &&
+          contact.champion &&
+          contact.companyId
+        ) {
+          const company = companies.find((c) => c.id === contact.companyId)
+          if (company) {
+            const nextStage = resolveAutoMoveStage(company.stage, contact.contactStatus)
+            if (nextStage) {
+              companies = companies.map((c) =>
+                c.id === company.id ? { ...c, stage: nextStage } : c,
+              )
+            }
+          }
         }
         return { companies, contacts }
       })

--- a/src/lib/championCard.ts
+++ b/src/lib/championCard.ts
@@ -1,0 +1,43 @@
+import type { Company, Contact } from '../types.js'
+
+export const NOTE_PREVIEW_MAX = 60
+
+export function findChampion(contacts: Contact[], companyId: string): Contact | null {
+  return contacts.find((c) => c.companyId === companyId && c.champion) ?? null
+}
+
+export function buildCardBadges(
+  company: Company,
+  contacts: Contact[],
+  todayIso: string,
+): { contactCount: number; hasChampion: boolean; followUpDueToday: boolean } {
+  const companyContacts = contacts.filter((c) => c.companyId === company.id)
+  const champion = findChampion(contacts, company.id)
+  return {
+    contactCount: companyContacts.length,
+    hasChampion: champion !== null,
+    followUpDueToday: company.nextFollowUp === todayIso || champion?.nextFollowUp === todayIso,
+  }
+}
+
+export function buildChampionTrail(
+  champion: Contact | null,
+): { header: string; note: string | null; followUp: string | null } | null {
+  if (!champion) return null
+  const header = `★ ${champion.contactName} · ${champion.contactStatus}`
+  const note = champion.notes
+    ? `Note: ${
+        champion.notes.length > NOTE_PREVIEW_MAX
+          ? `${champion.notes.slice(0, NOTE_PREVIEW_MAX)}…`
+          : champion.notes
+      }`
+    : null
+  const followUp = champion.nextFollowUp
+    ? `FU ${new Intl.DateTimeFormat('en-IN', {
+        timeZone: 'Asia/Kolkata',
+        day: 'numeric',
+        month: 'short',
+      }).format(new Date(champion.nextFollowUp))}`
+    : null
+  return { header, note, followUp }
+}

--- a/src/lib/championCard.ts
+++ b/src/lib/championCard.ts
@@ -2,6 +2,32 @@ import type { Company, Contact } from '../types.js'
 
 export const NOTE_PREVIEW_MAX = 60
 
+/**
+ * The single calendar-day policy shared by the "Due today" badge and the champion
+ * follow-up line. Both must agree on what "today" is, or near midnight a follow-up
+ * dated for the IST day could render "Due today" while the trail line shows a
+ * different day (or vice versa).
+ */
+export const IST_TZ = 'Asia/Kolkata'
+
+/**
+ * Today's calendar day in the {@link IST_TZ} timezone, as a `YYYY-MM-DD` string.
+ *
+ * Follow-up dates are stored as bare `YYYY-MM-DD` values and the trail formats them
+ * in Asia/Kolkata, so "today" must be resolved with the same calendar to compare
+ * correctly. `now` is injectable for deterministic tests.
+ */
+export function istToday(now: Date = new Date()): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: IST_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(now)
+  const part = (type: string) => parts.find((p) => p.type === type)?.value ?? ''
+  return `${part('year')}-${part('month')}-${part('day')}`
+}
+
 export function findChampion(contacts: Contact[], companyId: string): Contact | null {
   return contacts.find((c) => c.companyId === companyId && c.champion) ?? null
 }
@@ -9,14 +35,14 @@ export function findChampion(contacts: Contact[], companyId: string): Contact | 
 export function buildCardBadges(
   company: Company,
   contacts: Contact[],
-  todayIso: string,
+  today: string = istToday(),
 ): { contactCount: number; hasChampion: boolean; followUpDueToday: boolean } {
   const companyContacts = contacts.filter((c) => c.companyId === company.id)
   const champion = findChampion(contacts, company.id)
   return {
     contactCount: companyContacts.length,
     hasChampion: champion !== null,
-    followUpDueToday: company.nextFollowUp === todayIso || champion?.nextFollowUp === todayIso,
+    followUpDueToday: company.nextFollowUp === today || champion?.nextFollowUp === today,
   }
 }
 
@@ -34,7 +60,7 @@ export function buildChampionTrail(
     : null
   const followUp = champion.nextFollowUp
     ? `FU ${new Intl.DateTimeFormat('en-IN', {
-        timeZone: 'Asia/Kolkata',
+        timeZone: IST_TZ,
         day: 'numeric',
         month: 'short',
       }).format(new Date(champion.nextFollowUp))}`

--- a/src/lib/championSync.ts
+++ b/src/lib/championSync.ts
@@ -1,0 +1,26 @@
+import { STAGES } from '../types.js'
+import type { ContactStatus, Stage } from '../types.js'
+
+export const CHAMPION_STATUS_TO_STAGE: Record<ContactStatus, Stage | null> = {
+  'Not Contacted': null,
+  "Didn't Pick": null,
+  'Connected - Got Referral': 'Follow-up',
+  'Connected - Not Right Person': 'Follow-up',
+  'Connected - Future Follow-up': 'Follow-up',
+  'Interested': 'Discovery Call Done',
+  'Called': 'Discovery Call Done',
+  'No Answer': null,
+  'Follow-up Required': 'Follow-up',
+  'Rejected': 'Not Interested',
+}
+
+export function resolveAutoMoveStage(
+  currentStage: Stage,
+  championStatus: ContactStatus,
+): Stage | null {
+  if (currentStage === 'Closed Won' || currentStage === 'Closed Lost') return null
+  const target = CHAMPION_STATUS_TO_STAGE[championStatus]
+  if (target === null) return null
+  if (STAGES.indexOf(target) <= STAGES.indexOf(currentStage)) return null
+  return target
+}

--- a/testing/e2e/champion-sync.spec.ts
+++ b/testing/e2e/champion-sync.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect, type Page } from '@playwright/test'
+import { loginAsFounder, navTo } from './helpers'
+
+/**
+ * Issue #29 — a champion contact's status change auto-moves its company on the Kanban,
+ * and the company card renders the champion trail + badges. A non-champion change must
+ * neither move the company nor leak into the trail.
+ *
+ * Setup + edits go through the real UI (Modal here has no role="dialog", so we drive it
+ * by label/heading like the other specs). Each run creates its own dedicated company and
+ * two contacts (unique names), so it never relies on shared seed rows.
+ */
+
+const cardSelector = (companyId: string) =>
+  `[data-testid="company-card"][data-company-id="${companyId}"]`
+
+/** The KanbanColumn root whose header <h3> is exactly `stage`. */
+function stageColumn(page: Page, stage: string) {
+  return page.locator(`div:has(> div > h3:text-is("${stage}"))`)
+}
+
+async function addCompany(page: Page, name: string): Promise<string> {
+  await navTo(page, 'Sales Pipeline')
+  await page.getByRole('button', { name: '+ Add company' }).click()
+  await expect(page.getByRole('heading', { name: 'Add company' })).toBeVisible()
+  await page.getByLabel('Company Name *').fill(name)
+  await page.getByLabel('Stage').selectOption('Lead Added')
+  await page.getByRole('button', { name: 'Add company', exact: true }).click()
+  await expect(page.getByRole('heading', { name: 'Add company' })).toHaveCount(0)
+
+  const card = page.locator('[data-testid="company-card"]').filter({ hasText: name }).first()
+  await expect(card).toBeVisible()
+  const id = await card.getAttribute('data-company-id')
+  expect(id).toBeTruthy()
+  return id as string
+}
+
+async function addContact(
+  page: Page,
+  opts: { name: string; company: string; email: string; champion: boolean },
+) {
+  await navTo(page, 'Contacts')
+  await page.getByRole('button', { name: '+ Add contact' }).click()
+  await expect(page.getByRole('heading', { name: 'Add contact' })).toBeVisible()
+  await page.getByLabel('Contact Name *').fill(opts.name)
+  await page.locator('form select').first().selectOption({ label: opts.company })
+  await page.getByLabel('Email').fill(opts.email)
+  if (opts.champion) await page.locator('form input[type="checkbox"]').first().check()
+  await page.getByRole('button', { name: 'Add contact', exact: true }).click()
+  await expect(page.getByRole('heading', { name: 'Add contact' })).toHaveCount(0)
+}
+
+async function openContact(page: Page, name: string) {
+  await navTo(page, 'Contacts')
+  await page.getByRole('button', { name: /All Contacts/ }).click()
+  await page.locator('main table').getByText(name).first().click()
+  await expect(page.getByRole('heading', { name })).toBeVisible()
+}
+
+test.describe('Champion → company auto-move (issue #29)', () => {
+  test('champion status change moves the company + renders trail/badges; non-champion does not', async ({
+    page,
+  }) => {
+    await loginAsFounder(page)
+
+    const stamp = Date.now()
+    const companyName = `AutoMove Co ${stamp}`
+    const championName = `Priya Champion ${stamp}`
+    const sidekickName = `Sam Sidekick ${stamp}`
+    const championNote = `E2E champion note ${stamp}`
+
+    // (1) Dedicated company (Lead Added) + champion + non-champion contact.
+    const companyId = await addCompany(page, companyName)
+    await addContact(page, {
+      name: championName,
+      company: companyName,
+      email: `priya.${stamp}@automove.example`,
+      champion: true,
+    })
+    await addContact(page, {
+      name: sidekickName,
+      company: companyName,
+      email: `sam.${stamp}@automove.example`,
+      champion: false,
+    })
+
+    // (2) Open the champion, set status Interested + note + follow-up, save.
+    await openContact(page, championName)
+    await page.getByLabel('Contact Status').selectOption('Interested')
+    await page.getByLabel('Notes', { exact: true }).fill(championNote)
+    await page.getByLabel('Next Follow-up').fill('2026-08-15')
+    await page.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByRole('heading', { name: championName })).toHaveCount(0)
+
+    // (3) + (4) Card is in the Discovery Call Done column with trail + badges.
+    await navTo(page, 'Sales Pipeline')
+    await expect(
+      stageColumn(page, 'Discovery Call Done').locator(cardSelector(companyId)),
+    ).toBeVisible()
+    await expect(stageColumn(page, 'Lead Added').locator(cardSelector(companyId))).toHaveCount(0)
+
+    const badges = page.locator(`[data-testid="card-badges"][data-company-id="${companyId}"]`)
+    await expect(badges).toContainText('2 contacts')
+    await expect(badges).toContainText('★ Champion')
+
+    const trail = page.locator(`[data-testid="champion-trail"][data-company-id="${companyId}"]`)
+    await expect(trail).toContainText(championName)
+    await expect(trail).toContainText('Interested')
+    await expect(trail).toContainText(championNote)
+    await expect(trail).toContainText('FU') // champion follow-up line
+
+    // (5) Update the NON-champion to a status that WOULD move a champion forward
+    // ('Follow-up Required' → 'Follow-up'); the company must stay put and the trail
+    // must keep showing the champion, never the non-champion.
+    await openContact(page, sidekickName)
+    await page.getByLabel('Contact Status').selectOption('Follow-up Required')
+    await page.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByRole('heading', { name: sidekickName })).toHaveCount(0)
+
+    await navTo(page, 'Sales Pipeline')
+    await expect(
+      stageColumn(page, 'Discovery Call Done').locator(cardSelector(companyId)),
+    ).toBeVisible()
+    await expect(stageColumn(page, 'Follow-up').locator(cardSelector(companyId))).toHaveCount(0)
+
+    const trailAfter = page.locator(
+      `[data-testid="champion-trail"][data-company-id="${companyId}"]`,
+    )
+    await expect(trailAfter).toContainText(championName)
+    await expect(trailAfter).toContainText('Interested')
+    await expect(trailAfter).not.toContainText(sidekickName)
+    await expect(trailAfter).not.toContainText('Follow-up Required')
+  })
+})

--- a/testing/e2e/champion-sync.spec.ts
+++ b/testing/e2e/champion-sync.spec.ts
@@ -19,12 +19,24 @@ function stageColumn(page: Page, stage: string) {
   return page.locator(`div:has(> div > h3:text-is("${stage}"))`)
 }
 
-async function addCompany(page: Page, name: string): Promise<string> {
+/** Today's calendar day in Asia/Kolkata as `YYYY-MM-DD` — the same policy the card badge uses. */
+function istTodayIso(): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Kolkata',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date())
+  const part = (type: string) => parts.find((p) => p.type === type)?.value ?? ''
+  return `${part('year')}-${part('month')}-${part('day')}`
+}
+
+async function addCompany(page: Page, name: string, stage: string = 'Lead Added'): Promise<string> {
   await navTo(page, 'Sales Pipeline')
   await page.getByRole('button', { name: '+ Add company' }).click()
   await expect(page.getByRole('heading', { name: 'Add company' })).toBeVisible()
   await page.getByLabel('Company Name *').fill(name)
-  await page.getByLabel('Stage').selectOption('Lead Added')
+  await page.getByLabel('Stage').selectOption(stage)
   await page.getByRole('button', { name: 'Add company', exact: true }).click()
   await expect(page.getByRole('heading', { name: 'Add company' })).toHaveCount(0)
 
@@ -130,5 +142,122 @@ test.describe('Champion → company auto-move (issue #29)', () => {
     await expect(trailAfter).toContainText('Interested')
     await expect(trailAfter).not.toContainText(sidekickName)
     await expect(trailAfter).not.toContainText('Follow-up Required')
+  })
+
+  test('a champion follow-up due today (Asia/Kolkata) renders the "Due today" badge', async ({
+    page,
+  }) => {
+    await loginAsFounder(page)
+
+    const stamp = Date.now()
+    const companyName = `DueToday Co ${stamp}`
+    const championName = `Deepa DueToday ${stamp}`
+
+    const companyId = await addCompany(page, companyName)
+    await addContact(page, {
+      name: championName,
+      company: companyName,
+      email: `deepa.${stamp}@duetoday.example`,
+      champion: true,
+    })
+
+    // Follow-up dated for *today* in the SAME Asia/Kolkata calendar the badge resolves.
+    await openContact(page, championName)
+    await page.getByLabel('Contact Status').selectOption('Interested')
+    await page.getByLabel('Next Follow-up').fill(istTodayIso())
+    await page.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByRole('heading', { name: championName })).toHaveCount(0)
+
+    await navTo(page, 'Sales Pipeline')
+    const badges = page.locator(`[data-testid="card-badges"][data-company-id="${companyId}"]`)
+    await expect(badges).toContainText('Due today')
+  })
+
+  test('a rejected champion moves its company to the Not Interested column', async ({ page }) => {
+    await loginAsFounder(page)
+
+    const stamp = Date.now()
+    const companyName = `Rejected Co ${stamp}`
+    const championName = `Ravi Rejected ${stamp}`
+
+    const companyId = await addCompany(page, companyName)
+    await addContact(page, {
+      name: championName,
+      company: companyName,
+      email: `ravi.${stamp}@rejected.example`,
+      champion: true,
+    })
+
+    await openContact(page, championName)
+    await page.getByLabel('Contact Status').selectOption('Rejected')
+    await page.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByRole('heading', { name: championName })).toHaveCount(0)
+
+    await navTo(page, 'Sales Pipeline')
+    await expect(
+      stageColumn(page, 'Not Interested').locator(cardSelector(companyId)),
+    ).toBeVisible()
+    await expect(stageColumn(page, 'Lead Added').locator(cardSelector(companyId))).toHaveCount(0)
+  })
+
+  test('a company already ahead of the mapped stage never moves (never backward)', async ({
+    page,
+  }) => {
+    await loginAsFounder(page)
+
+    const stamp = Date.now()
+    const companyName = `Ahead Co ${stamp}`
+    const championName = `Anita Ahead ${stamp}`
+
+    // Starts at Demo Delivered — ahead of 'Interested' → Discovery Call Done.
+    const companyId = await addCompany(page, companyName, 'Demo Delivered')
+    await addContact(page, {
+      name: championName,
+      company: companyName,
+      email: `anita.${stamp}@ahead.example`,
+      champion: true,
+    })
+
+    await openContact(page, championName)
+    await page.getByLabel('Contact Status').selectOption('Interested')
+    await page.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByRole('heading', { name: championName })).toHaveCount(0)
+
+    await navTo(page, 'Sales Pipeline')
+    // Stays at Demo Delivered; must never be dragged backward to the earlier mapped stage.
+    await expect(
+      stageColumn(page, 'Demo Delivered').locator(cardSelector(companyId)),
+    ).toBeVisible()
+    await expect(
+      stageColumn(page, 'Discovery Call Done').locator(cardSelector(companyId)),
+    ).toHaveCount(0)
+  })
+
+  test('a Closed Won company is never auto-moved by a champion status change', async ({ page }) => {
+    await loginAsFounder(page)
+
+    const stamp = Date.now()
+    const companyName = `Won Co ${stamp}`
+    const championName = `Vikram Won ${stamp}`
+
+    const companyId = await addCompany(page, companyName, 'Closed Won')
+    await addContact(page, {
+      name: championName,
+      company: companyName,
+      email: `vikram.${stamp}@won.example`,
+      champion: true,
+    })
+
+    await openContact(page, championName)
+    await page.getByLabel('Contact Status').selectOption('Interested')
+    await page.getByRole('button', { name: 'Save changes' }).click()
+    await expect(page.getByRole('heading', { name: championName })).toHaveCount(0)
+
+    await navTo(page, 'Sales Pipeline')
+    // A terminal stage is frozen — the champion move must not pull it out of Closed Won.
+    await expect(stageColumn(page, 'Closed Won').locator(cardSelector(companyId))).toBeVisible()
+    await expect(
+      stageColumn(page, 'Discovery Call Done').locator(cardSelector(companyId)),
+    ).toHaveCount(0)
   })
 })

--- a/testing/functional/api/championSync.test.ts
+++ b/testing/functional/api/championSync.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import { api, loginAs, SEED } from './helpers'
+
+/**
+ * Issue #29 — a champion contact's status change auto-moves its company on the Kanban.
+ *
+ * Locked mapping (contract.md): a champion advancing to 'Interested' while the company
+ * is at 'Lead Added' auto-advances the company to 'Discovery Call Done'. Non-champion
+ * updates never move the company, and company `notes` are never touched by a contact patch.
+ * Every test creates its own dedicated company + contacts — no reliance on shared seed rows.
+ */
+
+let seq = 0
+const uniq = () => `${Date.now()}-${++seq}`
+
+type CompanyRow = { id: string; stage: string; notes: string }
+
+async function createCompany(
+  token: string,
+  fields: Record<string, unknown> = {},
+): Promise<CompanyRow> {
+  const res = await api<CompanyRow>('/api/companies', {
+    body: {
+      companyName: `Champion Co ${uniq()}`,
+      stage: 'Lead Added',
+      industry: 'SaaS',
+      location: 'Remote',
+      intent: 'Warm',
+      ...fields,
+    },
+    token,
+  })
+  expect(res.status).toBe(201)
+  return res.data
+}
+
+async function createContact(
+  token: string,
+  companyId: string,
+  fields: Record<string, unknown> = {},
+): Promise<{ id: string }> {
+  const u = uniq()
+  const res = await api<{ id: string }>('/api/contacts', {
+    body: {
+      companyId,
+      contactName: `Contact ${u}`,
+      email: `contact.${u}@champion.example`,
+      contactStatus: 'Not Contacted',
+      champion: false,
+      ...fields,
+    },
+    token,
+  })
+  expect(res.status).toBe(201)
+  return res.data
+}
+
+async function getCompany(token: string, companyId: string): Promise<CompanyRow | undefined> {
+  const boot = await api<{ companies: CompanyRow[] }>('/api/bootstrap', { token })
+  expect(boot.status).toBe(200)
+  return boot.data.companies.find((c) => c.id === companyId)
+}
+
+describe('champion contact → company auto-move (issue #29)', () => {
+  it('advances the company stage per the mapping when the champion status changes', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const co = await createCompany(token)
+    expect(co.stage).toBe('Lead Added')
+    const contact = await createContact(token, co.id, { champion: true })
+
+    const patched = await api<{ contactStatus: string }>(`/api/contacts/${contact.id}`, {
+      method: 'PATCH',
+      body: { contactStatus: 'Interested' },
+      token,
+    })
+    // Response shape is unchanged — a bare mapped contact, not the company.
+    expect(patched.status).toBe(200)
+    expect(patched.data.contactStatus).toBe('Interested')
+
+    const after = await getCompany(token, co.id)
+    expect(after?.stage).toBe('Discovery Call Done')
+
+    await api(`/api/companies/${co.id}`, { method: 'DELETE', token })
+  })
+
+  it('does not move the company when a NON-champion contact status changes', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const co = await createCompany(token)
+    const contact = await createContact(token, co.id, { champion: false })
+
+    const patched = await api(`/api/contacts/${contact.id}`, {
+      method: 'PATCH',
+      body: { contactStatus: 'Interested' },
+      token,
+    })
+    expect(patched.status).toBe(200)
+
+    const after = await getCompany(token, co.id)
+    expect(after?.stage).toBe('Lead Added')
+
+    await api(`/api/companies/${co.id}`, { method: 'DELETE', token })
+  })
+
+  it('leaves companies.notes untouched when a contact note is patched', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const originalNotes = `Company notes ${uniq()}`
+    const co = await createCompany(token, { notes: originalNotes })
+    expect(co.notes).toBe(originalNotes)
+    const contact = await createContact(token, co.id, { champion: true })
+
+    const patched = await api(`/api/contacts/${contact.id}`, {
+      method: 'PATCH',
+      body: { notes: 'Champion-side note that must never leak onto the company' },
+      token,
+    })
+    expect(patched.status).toBe(200)
+
+    const after = await getCompany(token, co.id)
+    expect(after?.notes).toBe(originalNotes)
+    // A note-only patch carries no contactStatus change, so it never auto-moves either.
+    expect(after?.stage).toBe('Lead Added')
+
+    await api(`/api/companies/${co.id}`, { method: 'DELETE', token })
+  })
+
+  it('logs a stage-change activity marked source=champion_contact on auto-move', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const co = await createCompany(token)
+    const contact = await createContact(token, co.id, { champion: true })
+
+    await api(`/api/contacts/${contact.id}`, {
+      method: 'PATCH',
+      body: { contactStatus: 'Interested' },
+      token,
+    })
+
+    const lead = await api<{
+      events: Array<{ eventType: string; payload: Record<string, unknown> }>
+    }>(`/api/activity/lead/company/${co.id}`, { token })
+    expect(lead.status).toBe(200)
+
+    const autoMove = lead.data.events.find(
+      (e) => (e.payload as { source?: string })?.source === 'champion_contact',
+    )
+    expect(autoMove).toBeTruthy()
+    expect(autoMove?.eventType).toBe('company.stage_changed')
+    expect(autoMove?.payload.from).toBe('Lead Added')
+    expect(autoMove?.payload.to).toBe('Discovery Call Done')
+
+    await api(`/api/companies/${co.id}`, { method: 'DELETE', token })
+  })
+})

--- a/testing/functional/api/championSync.test.ts
+++ b/testing/functional/api/championSync.test.ts
@@ -150,3 +150,148 @@ describe('champion contact → company auto-move (issue #29)', () => {
     await api(`/api/companies/${co.id}`, { method: 'DELETE', token })
   })
 })
+
+/** Champion-sourced `company.stage_changed` events on a company's activity lead. */
+async function championStageMoves(
+  token: string,
+  companyId: string,
+): Promise<Array<{ eventType: string; payload: Record<string, unknown> }>> {
+  const lead = await api<{
+    events: Array<{ eventType: string; payload: Record<string, unknown> }>
+  }>(`/api/activity/lead/company/${companyId}`, { token })
+  expect(lead.status).toBe(200)
+  return lead.data.events.filter(
+    (e) =>
+      e.eventType === 'company.stage_changed' &&
+      (e.payload as { source?: string }).source === 'champion_contact',
+  )
+}
+
+type PatchRes = { contactStatus?: string; movedCompanyStage?: string | null }
+
+// The PATCH response echoes `movedCompanyStage` (string | null): the stage the company
+// was auto-advanced to, or null when no auto-move happened. Every case pins it exactly.
+function expectMovedStage(data: PatchRes, expected: string | null) {
+  expect(data.movedCompanyStage).toBe(expected)
+}
+
+describe('champion auto-move matrix (issue #29)', () => {
+  it('Rejected champion moves the company to Not Interested', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const co = await createCompany(token) // Lead Added
+    const contact = await createContact(token, co.id, { champion: true })
+
+    const patched = await api<PatchRes>(`/api/contacts/${contact.id}`, {
+      method: 'PATCH',
+      body: { contactStatus: 'Rejected' },
+      token,
+    })
+    expect(patched.status).toBe(200)
+    expect(patched.data.contactStatus).toBe('Rejected')
+
+    expect((await getCompany(token, co.id))?.stage).toBe('Not Interested')
+
+    const moves = await championStageMoves(token, co.id)
+    expect(moves).toHaveLength(1)
+    expect(moves[0].payload.from).toBe('Lead Added')
+    expect(moves[0].payload.to).toBe('Not Interested')
+    expectMovedStage(patched.data, 'Not Interested')
+
+    await api(`/api/companies/${co.id}`, { method: 'DELETE', token })
+  })
+
+  // A company sitting at a closed stage never auto-moves, even though 'Not Interested'
+  // (the Rejected target) is ahead of both closed stages in STAGES order.
+  for (const stage of ['Closed Won', 'Closed Lost'] as const) {
+    it(`does not move a company already at ${stage} (closed-company guard)`, async () => {
+      const { token } = await loginAs(SEED.founder)
+      const co = await createCompany(token, { stage })
+      expect(co.stage).toBe(stage)
+      const contact = await createContact(token, co.id, { champion: true })
+
+      const patched = await api<PatchRes>(`/api/contacts/${contact.id}`, {
+        method: 'PATCH',
+        body: { contactStatus: 'Rejected' },
+        token,
+      })
+      expect(patched.status).toBe(200)
+
+      expect((await getCompany(token, co.id))?.stage).toBe(stage)
+      expect(await championStageMoves(token, co.id)).toHaveLength(0)
+      expectMovedStage(patched.data, null)
+
+      await api(`/api/companies/${co.id}`, { method: 'DELETE', token })
+    })
+  }
+
+  it('does not move when the company is already AHEAD of the mapped stage', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const co = await createCompany(token, { stage: 'Follow-up' })
+    const contact = await createContact(token, co.id, { champion: true })
+
+    // Interested → 'Discovery Call Done', which sits BEHIND 'Follow-up'.
+    const patched = await api<PatchRes>(`/api/contacts/${contact.id}`, {
+      method: 'PATCH',
+      body: { contactStatus: 'Interested' },
+      token,
+    })
+    expect(patched.status).toBe(200)
+
+    expect((await getCompany(token, co.id))?.stage).toBe('Follow-up')
+    expect(await championStageMoves(token, co.id)).toHaveLength(0)
+    expectMovedStage(patched.data, null)
+
+    await api(`/api/companies/${co.id}`, { method: 'DELETE', token })
+  })
+
+  it('does not move when the company is already AT the mapped stage (strictly forward only)', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const co = await createCompany(token, { stage: 'Discovery Call Done' })
+    const contact = await createContact(token, co.id, { champion: true })
+
+    // Interested → 'Discovery Call Done' equals the current stage, so no move.
+    const patched = await api<PatchRes>(`/api/contacts/${contact.id}`, {
+      method: 'PATCH',
+      body: { contactStatus: 'Interested' },
+      token,
+    })
+    expect(patched.status).toBe(200)
+
+    expect((await getCompany(token, co.id))?.stage).toBe('Discovery Call Done')
+    expect(await championStageMoves(token, co.id)).toHaveLength(0)
+    expectMovedStage(patched.data, null)
+
+    await api(`/api/companies/${co.id}`, { method: 'DELETE', token })
+  })
+
+  it('a same-status PATCH neither moves the company nor logs a second stage change', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const co = await createCompany(token) // Lead Added
+    const contact = await createContact(token, co.id, { champion: true })
+
+    // First real change advances Lead Added → Discovery Call Done (one champion move).
+    const first = await api<PatchRes>(`/api/contacts/${contact.id}`, {
+      method: 'PATCH',
+      body: { contactStatus: 'Interested' },
+      token,
+    })
+    expect(first.status).toBe(200)
+    expect((await getCompany(token, co.id))?.stage).toBe('Discovery Call Done')
+    expect(await championStageMoves(token, co.id)).toHaveLength(1)
+    expectMovedStage(first.data, 'Discovery Call Done')
+
+    // Re-PATCH the SAME status: no status_changed fires, so there is no auto-move and no
+    // new company.stage_changed activity — the champion-move count stays at exactly one.
+    const again = await api<PatchRes>(`/api/contacts/${contact.id}`, {
+      method: 'PATCH',
+      body: { contactStatus: 'Interested' },
+      token,
+    })
+    expect(again.status).toBe(200)
+    expect((await getCompany(token, co.id))?.stage).toBe('Discovery Call Done')
+    expect(await championStageMoves(token, co.id)).toHaveLength(1)
+    expectMovedStage(again.data, null)
+
+    await api(`/api/companies/${co.id}`, { method: 'DELETE', token })
+  })
+})

--- a/testing/unit/activityMetrics.test.ts
+++ b/testing/unit/activityMetrics.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Unit coverage for the champion auto-move exclusion in `accumulateCallMetrics`
+ * (server/activity.ts). When a champion contact is Rejected, the PATCH handler both
+ * logs `contact.status_changed → Rejected` AND mirrors it onto the company as a
+ * `company.stage_changed → Not Interested` tagged `source: 'champion_contact'`.
+ * Both events land in the same lead's stream and are folded through
+ * `accumulateCallMetrics` (see server/activityRoutes.ts `metricsForEvents`), so the
+ * `source !== 'champion_contact'` guard is what stops ONE rejection from counting as
+ * TWO "not interested" — the regression this test locks down.
+ *
+ * `server/activity.ts` imports `./db.ts`, which throws at load unless a DB URL is set.
+ * The `pg.Pool` it builds is lazy (it never connects here), so a dummy URL set BEFORE
+ * a dynamic import lets the pure metric helpers load fully offline — no Postgres, no
+ * network, no docker.
+ */
+process.env.DATABASE_URL ??= 'postgresql://unit:unit@127.0.0.1:5432/unit_no_connect'
+
+const { accumulateCallMetrics, emptyCallMetrics } = await import('../../server/activity')
+
+describe('accumulateCallMetrics — champion auto-move is not double-counted', () => {
+  it('counts a Rejected champion exactly once and ignores the champion_contact mirror', () => {
+    const metrics = emptyCallMetrics()
+
+    // The contact rejection is the single "not interested" signal.
+    accumulateCallMetrics(metrics, 'contact.status_changed', { from: 'Interested', to: 'Rejected' })
+    expect(metrics.notInterested).toBe(1)
+
+    // The auto-move re-reports the same rejection on the company. Because it carries
+    // source=champion_contact it MUST be skipped — otherwise notInterested inflates to 2.
+    accumulateCallMetrics(metrics, 'company.stage_changed', {
+      from: 'Lead Added',
+      to: 'Not Interested',
+      source: 'champion_contact',
+    })
+    expect(metrics.notInterested).toBe(1)
+  })
+
+  it('still counts a direct (non-champion) company move to Not Interested', () => {
+    // Discriminator: the guard excludes champion mirrors specifically, not every
+    // company.stage_changed → Not Interested. A manual/human move is real and counts.
+    const noSource = emptyCallMetrics()
+    accumulateCallMetrics(noSource, 'company.stage_changed', { from: 'Lead Added', to: 'Not Interested' })
+    expect(noSource.notInterested).toBe(1)
+
+    const manualSource = emptyCallMetrics()
+    accumulateCallMetrics(manualSource, 'company.stage_changed', {
+      from: 'Lead Added',
+      to: 'Not Interested',
+      source: 'manual',
+    })
+    expect(manualSource.notInterested).toBe(1)
+  })
+
+  it('does not count champion_contact mirrors for other stages either (demo/converted)', () => {
+    // The guard wraps the whole company.stage_changed block, so champion mirrors never
+    // touch demo/converted counters, only ever the direct moves do.
+    const champion = emptyCallMetrics()
+    accumulateCallMetrics(champion, 'company.stage_changed', {
+      to: 'Closed Won',
+      source: 'champion_contact',
+    })
+    accumulateCallMetrics(champion, 'company.stage_changed', {
+      to: 'Demo Scheduled',
+      source: 'champion_contact',
+    })
+    expect(champion.converted).toBe(0)
+    expect(champion.demo).toBe(0)
+
+    const direct = emptyCallMetrics()
+    accumulateCallMetrics(direct, 'company.stage_changed', { to: 'Closed Won' })
+    accumulateCallMetrics(direct, 'company.stage_changed', { to: 'Demo Scheduled' })
+    expect(direct.converted).toBe(1)
+    expect(direct.demo).toBe(1)
+  })
+})

--- a/testing/unit/championCard.test.ts
+++ b/testing/unit/championCard.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NOTE_PREVIEW_MAX,
+  buildCardBadges,
+  buildChampionTrail,
+  findChampion,
+} from '../../src/lib/championCard'
+import type { Company, Contact } from '../../src/types'
+
+function contact(partial: Partial<Contact> & Pick<Contact, 'id'>): Contact {
+  return {
+    contactName: 'Test Contact',
+    companyId: 'co-1',
+    role: '',
+    phone: '',
+    email: '',
+    linkedInProfile: '',
+    contactStatus: 'Not Contacted',
+    champion: false,
+    lastContacted: null,
+    nextFollowUp: null,
+    notes: '',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...partial,
+  }
+}
+
+function company(partial: Partial<Company> & Pick<Company, 'id'>): Company {
+  return {
+    companyName: 'Test Co',
+    stage: 'Lead Added',
+    industry: 'SaaS',
+    location: '',
+    estimatedCallVolume: null,
+    employeeCount: null,
+    intent: 'Warm',
+    offeredPrice: null,
+    primaryContactId: null,
+    assignedTo: 'u1',
+    lastContacted: null,
+    nextFollowUp: null,
+    notes: '',
+    sourceLink: '',
+    companyWebsite: '',
+    linkedInCompany: '',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...partial,
+  }
+}
+
+const TODAY = '2026-07-19'
+
+describe('findChampion', () => {
+  it('returns the champion contact for the company', () => {
+    const contacts = [
+      contact({ id: 'c1', companyId: 'co-1', champion: false }),
+      contact({ id: 'c2', companyId: 'co-1', champion: true }),
+    ]
+    expect(findChampion(contacts, 'co-1')?.id).toBe('c2')
+  })
+
+  it('returns null when the company has no champion', () => {
+    const contacts = [contact({ id: 'c1', companyId: 'co-1', champion: false })]
+    expect(findChampion(contacts, 'co-1')).toBeNull()
+  })
+
+  it('excludes champions belonging to other companies', () => {
+    const contacts = [contact({ id: 'c1', companyId: 'co-2', champion: true })]
+    expect(findChampion(contacts, 'co-1')).toBeNull()
+  })
+
+  it('returns the first champion when a company has several', () => {
+    const contacts = [
+      contact({ id: 'c1', companyId: 'co-1', champion: true, contactName: 'First' }),
+      contact({ id: 'c2', companyId: 'co-1', champion: true, contactName: 'Second' }),
+    ]
+    expect(findChampion(contacts, 'co-1')?.id).toBe('c1')
+  })
+})
+
+describe('buildCardBadges', () => {
+  const co = company({ id: 'co-1' })
+
+  it('counts only the company own contacts and flags the champion', () => {
+    const contacts = [
+      contact({ id: 'c1', companyId: 'co-1', champion: true }),
+      contact({ id: 'c2', companyId: 'co-1' }),
+      contact({ id: 'c3', companyId: 'co-2' }), // different company — must not be counted
+    ]
+    const badges = buildCardBadges(co, contacts, TODAY)
+    expect(badges.contactCount).toBe(2)
+    expect(badges.hasChampion).toBe(true)
+    expect(badges.followUpDueToday).toBe(false)
+  })
+
+  it('reports no champion when none is flagged', () => {
+    const contacts = [contact({ id: 'c1', companyId: 'co-1', champion: false })]
+    expect(buildCardBadges(co, contacts, TODAY).hasChampion).toBe(false)
+  })
+
+  it('flags follow-up-due-today when the company follow-up is today', () => {
+    const badges = buildCardBadges(company({ id: 'co-1', nextFollowUp: TODAY }), [], TODAY)
+    expect(badges.followUpDueToday).toBe(true)
+  })
+
+  it('flags follow-up-due-today when the champion follow-up is today', () => {
+    const contacts = [
+      contact({ id: 'c1', companyId: 'co-1', champion: true, nextFollowUp: TODAY }),
+    ]
+    expect(buildCardBadges(co, contacts, TODAY).followUpDueToday).toBe(true)
+  })
+
+  it('does not flag follow-up-due-today for a non-champion contact follow-up', () => {
+    const contacts = [
+      contact({ id: 'c1', companyId: 'co-1', champion: false, nextFollowUp: TODAY }),
+    ]
+    expect(buildCardBadges(co, contacts, TODAY).followUpDueToday).toBe(false)
+  })
+})
+
+describe('buildChampionTrail', () => {
+  it('returns null when there is no champion', () => {
+    expect(buildChampionTrail(null)).toBeNull()
+  })
+
+  it('builds the header from the champion name and status', () => {
+    const trail = buildChampionTrail(
+      contact({
+        id: 'c1',
+        champion: true,
+        contactName: 'Priya Sharma',
+        contactStatus: 'Interested',
+      }),
+    )
+    expect(trail?.header).toBe('★ Priya Sharma · Interested')
+  })
+
+  it('returns a null note when the champion has no notes', () => {
+    const trail = buildChampionTrail(contact({ id: 'c1', champion: true, notes: '' }))
+    expect(trail?.note).toBeNull()
+  })
+
+  it('shows a short note verbatim behind a Note: prefix', () => {
+    const trail = buildChampionTrail(contact({ id: 'c1', champion: true, notes: 'Quick call' }))
+    expect(trail?.note).toBe('Note: Quick call')
+  })
+
+  it('keeps a note of exactly NOTE_PREVIEW_MAX chars without truncation', () => {
+    const exact = 'a'.repeat(NOTE_PREVIEW_MAX)
+    const trail = buildChampionTrail(contact({ id: 'c1', champion: true, notes: exact }))
+    expect(trail?.note).toBe(`Note: ${exact}`)
+  })
+
+  it('truncates a long note to NOTE_PREVIEW_MAX chars with an ellipsis', () => {
+    const long = 'a'.repeat(NOTE_PREVIEW_MAX) + 'b'.repeat(20)
+    const trail = buildChampionTrail(contact({ id: 'c1', champion: true, notes: long }))
+    expect(trail?.note).toBe(`Note: ${'a'.repeat(NOTE_PREVIEW_MAX)}…`)
+    expect(trail?.note).not.toContain('b')
+  })
+
+  it('formats the follow-up when present and is null when absent', () => {
+    const withFu = buildChampionTrail(
+      contact({ id: 'c1', champion: true, nextFollowUp: '2026-07-22' }),
+    )
+    expect(withFu?.followUp).toMatch(/^FU /)
+    expect(withFu?.followUp).toContain('22')
+
+    const noFu = buildChampionTrail(contact({ id: 'c1', champion: true, nextFollowUp: null }))
+    expect(noFu?.followUp).toBeNull()
+  })
+
+  it('exposes NOTE_PREVIEW_MAX as 60', () => {
+    expect(NOTE_PREVIEW_MAX).toBe(60)
+  })
+})

--- a/testing/unit/championCard.test.ts
+++ b/testing/unit/championCard.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  IST_TZ,
   NOTE_PREVIEW_MAX,
   buildCardBadges,
   buildChampionTrail,
   findChampion,
+  istToday,
 } from '../../src/lib/championCard'
 import type { Company, Contact } from '../../src/types'
 
@@ -49,6 +51,32 @@ function company(partial: Partial<Company> & Pick<Company, 'id'>): Company {
 }
 
 const TODAY = '2026-07-19'
+
+describe('istToday', () => {
+  it('anchors the calendar-day policy to Asia/Kolkata', () => {
+    expect(IST_TZ).toBe('Asia/Kolkata')
+  })
+
+  it('returns the Asia/Kolkata calendar day as YYYY-MM-DD', () => {
+    // IST is UTC+5:30, so 20:00 UTC on the 19th is already 01:30 on the 20th in Kolkata.
+    expect(istToday(new Date('2026-07-19T20:00:00Z'))).toBe('2026-07-20')
+    // 05:00 UTC on the 19th is 10:30 IST — still the 19th.
+    expect(istToday(new Date('2026-07-19T05:00:00Z'))).toBe('2026-07-19')
+  })
+
+  it('rolls over at IST midnight (18:30 UTC), not at browser-local midnight', () => {
+    expect(istToday(new Date('2026-07-19T18:29:59Z'))).toBe('2026-07-19') // 23:59:59 IST
+    expect(istToday(new Date('2026-07-19T18:30:00Z'))).toBe('2026-07-20') // 00:00:00 IST
+  })
+
+  it('zero-pads single-digit months and days', () => {
+    expect(istToday(new Date('2026-01-05T12:00:00Z'))).toBe('2026-01-05')
+  })
+
+  it('defaults to the current instant and always yields a well-formed date', () => {
+    expect(istToday()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
 
 describe('findChampion', () => {
   it('returns the champion contact for the company', () => {
@@ -115,6 +143,49 @@ describe('buildCardBadges', () => {
       contact({ id: 'c1', companyId: 'co-1', champion: false, nextFollowUp: TODAY }),
     ]
     expect(buildCardBadges(co, contacts, TODAY).followUpDueToday).toBe(false)
+  })
+
+  it('flags Due today when the company follow-up equals the Asia/Kolkata calendar day', () => {
+    // Near IST midnight: 20:00 UTC on the 19th is already the 20th in Kolkata.
+    const istDay = istToday(new Date('2026-07-19T20:00:00Z'))
+    expect(istDay).toBe('2026-07-20')
+    const badges = buildCardBadges(company({ id: 'co-1', nextFollowUp: istDay }), [], istDay)
+    expect(badges.followUpDueToday).toBe(true)
+  })
+
+  it('flags Due today when the champion follow-up equals the Asia/Kolkata calendar day', () => {
+    const istDay = istToday(new Date('2026-07-19T20:00:00Z'))
+    const contacts = [
+      contact({ id: 'c1', companyId: 'co-1', champion: true, nextFollowUp: istDay }),
+    ]
+    expect(buildCardBadges(co, contacts, istDay).followUpDueToday).toBe(true)
+  })
+
+  it('compares against the IST day, not the browser-local day, near midnight', () => {
+    // The original bug: the badge used browser-local todayIso() while the trail formats
+    // in Asia/Kolkata. At 20:00 UTC the IST day has already rolled to the 20th, so a
+    // follow-up dated for the IST day must flag even though local time still reads the 19th.
+    const istDay = istToday(new Date('2026-07-19T20:00:00Z')) // '2026-07-20'
+    const browserLocalDay = '2026-07-19' // what the stale todayIso() would have compared against
+    expect(istDay).not.toBe(browserLocalDay)
+    expect(
+      buildCardBadges(company({ id: 'co-1', nextFollowUp: istDay }), [], istDay).followUpDueToday,
+    ).toBe(true)
+    expect(
+      buildCardBadges(company({ id: 'co-1', nextFollowUp: browserLocalDay }), [], istDay)
+        .followUpDueToday,
+    ).toBe(false)
+  })
+
+  it('derives the IST today itself when no reference day is passed', () => {
+    const todayIst = istToday()
+    expect(
+      buildCardBadges(company({ id: 'co-1', nextFollowUp: todayIst }), []).followUpDueToday,
+    ).toBe(true)
+    const contacts = [
+      contact({ id: 'c1', companyId: 'co-1', champion: true, nextFollowUp: todayIst }),
+    ]
+    expect(buildCardBadges(co, contacts).followUpDueToday).toBe(true)
   })
 })
 

--- a/testing/unit/championSync.test.ts
+++ b/testing/unit/championSync.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { CHAMPION_STATUS_TO_STAGE, resolveAutoMoveStage } from '../../src/lib/championSync'
+import { CONTACT_STATUSES } from '../../src/types'
+import type { ContactStatus, Stage } from '../../src/types'
+
+// Locked mapping from contract.md (issue #29).
+const EXPECTED: Record<ContactStatus, Stage | null> = {
+  'Not Contacted': null,
+  "Didn't Pick": null,
+  'No Answer': null,
+  Called: 'Discovery Call Done',
+  Interested: 'Discovery Call Done',
+  'Follow-up Required': 'Follow-up',
+  'Connected - Future Follow-up': 'Follow-up',
+  'Connected - Got Referral': 'Follow-up',
+  'Connected - Not Right Person': 'Follow-up',
+  Rejected: 'Not Interested',
+}
+
+describe('CHAMPION_STATUS_TO_STAGE', () => {
+  it('maps every champion status exactly as the contract specifies', () => {
+    expect(CHAMPION_STATUS_TO_STAGE).toEqual(EXPECTED)
+  })
+
+  it('has an entry for every ContactStatus (no missing keys)', () => {
+    for (const status of CONTACT_STATUSES) {
+      expect(status in CHAMPION_STATUS_TO_STAGE).toBe(true)
+    }
+  })
+})
+
+describe('resolveAutoMoveStage', () => {
+  it('returns null for the no-move statuses regardless of current stage', () => {
+    for (const status of ['Not Contacted', "Didn't Pick", 'No Answer'] as ContactStatus[]) {
+      expect(resolveAutoMoveStage('Lead Added', status)).toBeNull()
+    }
+  })
+
+  it('moves forward to the mapped stage', () => {
+    expect(resolveAutoMoveStage('Lead Added', 'Interested')).toBe('Discovery Call Done')
+    expect(resolveAutoMoveStage('Lead Added', 'Called')).toBe('Discovery Call Done')
+    expect(resolveAutoMoveStage('Lead Added', 'Follow-up Required')).toBe('Follow-up')
+    expect(resolveAutoMoveStage('Lead Added', 'Connected - Future Follow-up')).toBe('Follow-up')
+    expect(resolveAutoMoveStage('Lead Added', 'Connected - Got Referral')).toBe('Follow-up')
+    expect(resolveAutoMoveStage('Lead Added', 'Connected - Not Right Person')).toBe('Follow-up')
+    expect(resolveAutoMoveStage('Lead Added', 'Rejected')).toBe('Not Interested')
+  })
+
+  it('never moves backward (mapped target behind current stage)', () => {
+    // 'Discovery Call Done' sits behind 'Follow-up' in STAGES order.
+    expect(resolveAutoMoveStage('Follow-up', 'Interested')).toBeNull()
+    // 'Follow-up' sits behind 'Demo Scheduled'.
+    expect(resolveAutoMoveStage('Demo Scheduled', 'Follow-up Required')).toBeNull()
+  })
+
+  it('does not move when the mapped target equals the current stage (strictly forward only)', () => {
+    expect(resolveAutoMoveStage('Discovery Call Done', 'Interested')).toBeNull()
+    expect(resolveAutoMoveStage('Follow-up', 'Follow-up Required')).toBeNull()
+  })
+
+  it('never auto-moves a closed company', () => {
+    expect(resolveAutoMoveStage('Closed Won', 'Interested')).toBeNull()
+    // Rejected → Not Interested is forward of Closed Lost in STAGES order,
+    // but the closed-company guard takes precedence.
+    expect(resolveAutoMoveStage('Closed Lost', 'Rejected')).toBeNull()
+  })
+
+  it('moves Rejected → Not Interested from an active mid stage', () => {
+    expect(resolveAutoMoveStage('Follow-up', 'Rejected')).toBe('Not Interested')
+  })
+})

--- a/testing/unit/useCrmStore.test.ts
+++ b/testing/unit/useCrmStore.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { applyChampionAutoMove } from '../../src/hooks/useCrmStore'
+import type { Company, ContactStatus, Stage } from '../../src/types'
+
+// A champion contact whose status just changed to 'Interested'. Locally that
+// would derive a move Lead Added -> Discovery Call Done (see championSync), so
+// tests can tell a server-driven move apart from a locally-derived one.
+const champion = {
+  companyId: 'co-1',
+  champion: true,
+  contactStatus: 'Interested' as ContactStatus,
+}
+
+function makeCompany(overrides: Partial<Company> = {}): Company {
+  return {
+    id: 'co-1',
+    companyName: 'Acme',
+    stage: 'Lead Added',
+    industry: 'SaaS',
+    location: '',
+    estimatedCallVolume: null,
+    employeeCount: null,
+    intent: '',
+    offeredPrice: null,
+    primaryContactId: null,
+    assignedTo: '',
+    lastContacted: null,
+    nextFollowUp: null,
+    notes: '',
+    sourceLink: '',
+    companyWebsite: '',
+    linkedInCompany: '',
+    createdAt: '2026-01-01T00:00:00',
+    ...overrides,
+  }
+}
+
+function stageOf(companies: Company[], id: string): Stage | undefined {
+  return companies.find((c) => c.id === id)?.stage
+}
+
+describe('applyChampionAutoMove', () => {
+  it('moves the company to the server-returned stage (server is the source of truth)', () => {
+    const companies = [makeCompany({ id: 'co-1', stage: 'Lead Added' })]
+
+    // 'Demo Scheduled' is NOT what local derivation would pick ('Discovery Call
+    // Done'), so a pass proves the server value wins over local derivation.
+    const out = applyChampionAutoMove(companies, {
+      contact: champion,
+      prevContactStatus: 'Not Contacted',
+      statusPatched: true,
+      movedCompanyStage: 'Demo Scheduled',
+    })
+
+    expect(stageOf(out, 'co-1')).toBe('Demo Scheduled')
+    // Input is not mutated (pure transition).
+    expect(out).not.toBe(companies)
+    expect(stageOf(companies, 'co-1')).toBe('Lead Added')
+  })
+
+  it('leaves the stage unchanged when the server reports no move (null)', () => {
+    const companies = [makeCompany({ id: 'co-1', stage: 'Lead Added' })]
+
+    // Local derivation WOULD move ('Interested' => 'Discovery Call Done'); an
+    // explicit null from the server must suppress that.
+    const out = applyChampionAutoMove(companies, {
+      contact: champion,
+      prevContactStatus: 'Not Contacted',
+      statusPatched: true,
+      movedCompanyStage: null,
+    })
+
+    expect(stageOf(out, 'co-1')).toBe('Lead Added')
+  })
+
+  it('falls back to local derivation when the field is absent (older server)', () => {
+    const companies = [makeCompany({ id: 'co-1', stage: 'Lead Added' })]
+
+    const out = applyChampionAutoMove(companies, {
+      contact: champion,
+      prevContactStatus: 'Not Contacted',
+      statusPatched: true,
+      movedCompanyStage: undefined, // pre-field server omits it entirely
+    })
+
+    // resolveAutoMoveStage('Lead Added', 'Interested') === 'Discovery Call Done'
+    expect(stageOf(out, 'co-1')).toBe('Discovery Call Done')
+  })
+
+  it('server-returned stage moves only the owning company, leaving others', () => {
+    const companies = [
+      makeCompany({ id: 'co-1', stage: 'Lead Added' }),
+      makeCompany({ id: 'co-2', stage: 'Follow-up' }),
+    ]
+
+    const out = applyChampionAutoMove(companies, {
+      contact: { ...champion, companyId: 'co-1' },
+      prevContactStatus: 'Not Contacted',
+      statusPatched: true,
+      movedCompanyStage: 'Demo Scheduled',
+    })
+
+    expect(stageOf(out, 'co-1')).toBe('Demo Scheduled')
+    expect(stageOf(out, 'co-2')).toBe('Follow-up')
+  })
+
+  it('does not apply a server stage when the contact has no company', () => {
+    const companies = [makeCompany({ id: 'co-1', stage: 'Lead Added' })]
+
+    const out = applyChampionAutoMove(companies, {
+      contact: { ...champion, companyId: null },
+      prevContactStatus: 'Not Contacted',
+      statusPatched: true,
+      movedCompanyStage: 'Demo Scheduled',
+    })
+
+    expect(stageOf(out, 'co-1')).toBe('Lead Added')
+  })
+
+  it('absent field + non-champion contact makes no local move (legacy gate preserved)', () => {
+    const companies = [makeCompany({ id: 'co-1', stage: 'Lead Added' })]
+
+    const out = applyChampionAutoMove(companies, {
+      contact: { ...champion, champion: false },
+      prevContactStatus: 'Not Contacted',
+      statusPatched: true,
+      movedCompanyStage: undefined,
+    })
+
+    expect(stageOf(out, 'co-1')).toBe('Lead Added')
+  })
+
+  it('absent field + status not part of this patch makes no local move', () => {
+    const companies = [makeCompany({ id: 'co-1', stage: 'Lead Added' })]
+
+    const out = applyChampionAutoMove(companies, {
+      contact: champion,
+      prevContactStatus: 'Not Contacted',
+      statusPatched: false, // e.g. only notes were patched
+      movedCompanyStage: undefined,
+    })
+
+    expect(stageOf(out, 'co-1')).toBe('Lead Added')
+  })
+})


### PR DESCRIPTION
Fixes #29


Surfaces the champion contact directly on each Pipeline kanban card and lets a champion's
status changes nudge the company forward through the stages automatically — without ever
dragging a deal backward or overriding a manual move.

## What you get

- **Card badges** — every company card shows a contact count, a `★ Champion` marker when a
  champion exists, and a `Due today` marker when a follow-up is due today.
- **Champion trail** — a 2–3 line summary under the badges (champion only): `★ Name · Status`,
  an optional truncated note, and the champion's next follow-up date.
- **One-way auto-move** — when a champion's contact status changes, the company advances to the
  mapped stage if (and only if) that stage is *ahead* of where it is now. The move is computed by
  one shared helper so the server write and the client's local state always agree; the client
  mirrors it with no extra network round-trip.

## Status → stage mapping

The mapping is intentional and documented so it can be revisited later:

| Champion's new contact status                                  | Company moves to      |
| -------------------------------------------------------------- | --------------------- |
| `Called`, `Interested`                                         | `Discovery Call Done` |
| `Follow-up Required`, `Connected - Future Follow-up`           | `Follow-up`           |
| `Connected - Got Referral`, `Connected - Not Right Person`     | `Follow-up`           |
| `Rejected`                                                     | `Not Interested`      |
| `Not Contacted`, `Didn't Pick`, `No Answer`                    | — (no move)           |

Two choices worth calling out:

- **`Called` / `Interested` → `Discovery Call Done`, not `Follow-up`.** In the stage order,
  `Follow-up` comes *after* `Discovery Call Done`. A first real conversation means discovery is
  done — you're not at the follow-up stage yet — so we map to the earlier of the two.
- **`Rejected` → `Not Interested`, not `Closed Lost`.** `Closed Lost` implies losing a
  late-stage deal; a champion going cold early is better represented as `Not Interested`.

### Guardrails on the move

- **Never backward.** The company only moves when the mapped stage is strictly further along the
  stage order than its current stage (equal stage is a no-op).
- **Never touch a closed company.** No auto-move when the company is `Closed Won` or `Closed Lost`.
- **Only on a real change to a champion.** The move fires only when the *champion's* `contactStatus`
  actually changed value. Editing a non-champion contact never moves anything, and manual drags on
  the board are left completely alone.
- **First champion wins.** If a company somehow has more than one champion, the badges/trail use the
  first champion in stored contact order. (Edge case — a company is expected to have one.)
- **`Due today` is exact-match, not overdue.** The badge lights up when the company's *or* the
  champion's `nextFollowUp` equals today's date — it is not a past-due/overdue check.

## Trail formatting

- Note preview is truncated to 60 characters, with a `…` ellipsis appended only when it was
  actually cut (empty notes show no note line).
- The follow-up line renders as e.g. `FU 22 Jul`, formatted with
  `Intl.DateTimeFormat('en-IN', { timeZone: 'Asia/Kolkata', day: 'numeric', month: 'short' })` —
  matching the app's existing date formatters. `Asia/Kolkata` is deliberate: follow-ups are stored
  as date-only ISO strings (`YYYY-MM-DD`), so parsing them as UTC midnight and formatting in IST
  (which is ahead of UTC) keeps the same calendar day and avoids an off-by-one.

## Metrics: avoiding a double count

The auto-move reuses the existing `company.stage_changed` activity event (same event a manual drag
logs), tagged with `payload.source: 'champion_contact'` to distinguish it. Without care, that would
double-count a rejection in the SDR call metrics: a `Rejected` champion produces both a
`contact.status_changed → Rejected` event (already counted as "not interested") *and* the
auto-move's `company.stage_changed → Not Interested`.

`accumulateCallMetrics` in `server/activity.ts` now skips the `company.stage_changed` branch when
`payload.source === 'champion_contact'`, so the champion's rejection is counted once via the contact
path and the auto-move is treated purely as a board position change, not a second SDR outcome.

## Changes by area

- **Shared helpers (new, pure, no React):** `src/lib/championSync.ts` (the mapping +
  `resolveAutoMoveStage`, imported by both client and server) and `src/lib/championCard.ts`
  (badge and trail builders).
- **Backend:** `server/app.ts` adds the auto-move block to `PATCH /api/contacts/:id` — response
  shape is unchanged (still a bare mapped contact), and company `notes` are never touched.
  `server/activity.ts` adds the metrics-exclusion guard above.
- **Frontend:** `src/hooks/useCrmStore.ts` mirrors the move in local state after the PATCH resolves;
  `src/components/Pipeline.tsx` renders the badges and trail, computing today's date once per board
  render rather than per card.

## Tests

- **Unit** (`npm test`) — `4 files, 37 tests passing`, including `championSync.test.ts` (8: full
  status-mapping coverage incl. the no-move group, strictly-forward rule, equal-stage no-op, and
  closed-company guard) and `championCard.test.ts` (17: contact-count scoping, champion vs
  non-champion, due-today for company-or-champion, trail header, note truncation at exactly 60 with
  ellipsis, empty-note and no-follow-up states, first-of-multiple champions).
- **Functional API** (`npm run test:api`, against the Docker Postgres) — `3 files, 21 tests
  passing`, including 4 new cases: a champion status patch advances the company's stage as mapped;
  the same patch on a non-champion leaves the stage untouched; a champion note-only patch leaves
  `companies.notes` and stage unchanged; and the auto-move logs a `company.stage_changed` activity
  carrying `source: 'champion_contact'` with the from/to stages.
- `npx tsc -b` and `npm run lint` both clean.
- **UI e2e** (`npm run test:e2e`) — `17 tests passing`, including a new `champion-sync.spec.ts`: set a champion to Interested with a note and follow-up → the Pipeline card shows the badges and trail and the company lands in the Discovery Call Done column; updating a non-champion moves nothing and never appears in the trail.
