### PR TITLE
feat: redesign Contacts with search, filters, and lead insights

### DIFF
--- a/server/activity.ts
+++ b/server/activity.ts
@@ -1,6 +1,14 @@
 import { pool } from './db.js'
 import type { Pool, PoolClient } from 'pg'
 
+export type { FieldChange } from './activityFields.js'
+export {
+  collectFieldChanges,
+  formatFieldChangeSummary,
+  noteSnippet,
+  normalizeActivityValue,
+} from './activityFields.js'
+
 export const IDLE_MS = 45 * 60 * 1000
 export const ACTIVITY_TZ = 'Asia/Kolkata'
 
@@ -20,60 +28,6 @@ export interface LogActivityInput {
   summary: string
   payload?: Record<string, unknown>
   at?: Date
-}
-
-export interface FieldChange {
-  field: string
-  label: string
-  from: string | null
-  to: string | null
-}
-
-/** Normalize DB/API values for equality + display in activity payloads. */
-export function normalizeActivityValue(value: unknown): string | null {
-  if (value === undefined || value === null || value === '') return null
-  if (typeof value === 'boolean') return value ? 'true' : 'false'
-  if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? null : value.toISOString().slice(0, 10)
-  }
-  const s = String(value).trim()
-  return s === '' ? null : s
-}
-
-export function collectFieldChanges(
-  specs: Array<{
-    field: string
-    label: string
-    before: unknown
-    after: unknown
-    provided: boolean
-  }>,
-): FieldChange[] {
-  const changes: FieldChange[] = []
-  for (const spec of specs) {
-    if (!spec.provided) continue
-    const from = normalizeActivityValue(spec.before)
-    const to = normalizeActivityValue(spec.after)
-    if (from === to) continue
-    changes.push({ field: spec.field, label: spec.label, from, to })
-  }
-  return changes
-}
-
-export function formatFieldChangeSummary(name: string, changes: FieldChange[]): string {
-  if (changes.length === 1) {
-    const c = changes[0]!
-    return `${c.label}: ${c.from ?? '—'} → ${c.to ?? '—'} (${name})`
-  }
-  const labels = changes.map((c) => c.label).join(', ')
-  return `Updated ${labels} on ${name}`
-}
-
-export function noteSnippet(text: string | null, max = 160): string | null {
-  if (!text) return null
-  const oneLine = text.replace(/\s+/g, ' ').trim()
-  if (!oneLine) return null
-  return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine
 }
 
 const CALL_OUTCOME_STATUSES = new Set([

--- a/server/activityFields.ts
+++ b/server/activityFields.ts
@@ -1,0 +1,55 @@
+/** Pure activity field helpers — no DB imports (safe for unit tests). */
+
+export interface FieldChange {
+  field: string
+  label: string
+  from: string | null
+  to: string | null
+}
+
+/** Normalize DB/API values for equality + display in activity payloads. */
+export function normalizeActivityValue(value: unknown): string | null {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString().slice(0, 10)
+  }
+  const s = String(value).trim()
+  return s === '' ? null : s
+}
+
+export function collectFieldChanges(
+  specs: Array<{
+    field: string
+    label: string
+    before: unknown
+    after: unknown
+    provided: boolean
+  }>,
+): FieldChange[] {
+  const changes: FieldChange[] = []
+  for (const spec of specs) {
+    if (!spec.provided) continue
+    const from = normalizeActivityValue(spec.before)
+    const to = normalizeActivityValue(spec.after)
+    if (from === to) continue
+    changes.push({ field: spec.field, label: spec.label, from, to })
+  }
+  return changes
+}
+
+export function formatFieldChangeSummary(name: string, changes: FieldChange[]): string {
+  if (changes.length === 1) {
+    const c = changes[0]!
+    return `${c.label}: ${c.from ?? '—'} → ${c.to ?? '—'} (${name})`
+  }
+  const labels = changes.map((c) => c.label).join(', ')
+  return `Updated ${labels} on ${name}`
+}
+
+export function noteSnippet(text: string | null, max = 160): string | null {
+  if (!text) return null
+  const oneLine = text.replace(/\s+/g, ' ').trim()
+  if (!oneLine) return null
+  return oneLine.length > max ? `${oneLine.slice(0, max - 1)}…` : oneLine
+}

--- a/src/components/Contacts.tsx
+++ b/src/components/Contacts.tsx
@@ -1,16 +1,23 @@
-import { useMemo, useState } from 'react'
-import type { Contact, ContactView } from '../types'
+import { useEffect, useMemo, useState } from 'react'
+import type {
+  Contact,
+  ContactFilters,
+  ContactSortKey,
+  SortDirection,
+} from '../types'
 import type { CrmStore } from '../hooks/useCrmStore'
 import {
-  CONTACT_VIEW_GROUPS,
-  CONTACT_VIEW_HINTS,
-  filterContacts,
-  sortContactsForView,
+  CONTACT_DATE_RANGE_OPTIONS,
+  CONTACT_QUEUE_OPTIONS,
+  DEFAULT_CONTACT_FILTERS,
+  applyContactFilters,
+  buildContactInsights,
+  contactFiltersAreActive,
   statusColor,
 } from '../lib/views'
 import { logViewEvent } from '../lib/activity'
 import { ContactForm } from './ContactForm'
-import { Modal, btnPrimary } from './ui'
+import { FilterChip, FilterDropdown, Modal, SearchInput, btnPrimary } from './ui'
 
 interface ContactsProps {
   store: CrmStore
@@ -18,13 +25,19 @@ interface ContactsProps {
   stages?: string[]
 }
 
+function formatAddedDate(iso: string): string {
+  return iso.slice(0, 10) || '—'
+}
+
 function ContactRow({
   contact,
   companyName,
+  stage,
   onEdit,
 }: {
   contact: Contact
   companyName: string
+  stage: string
   onEdit: () => void
 }) {
   return (
@@ -49,6 +62,7 @@ function ContactRow({
       <div className="mt-2 flex flex-wrap gap-2 text-xs text-stone-600">
         <span>{companyName}</span>
         {contact.role ? <span>· {contact.role}</span> : null}
+        {stage ? <span>· {stage}</span> : null}
       </div>
       <div className="mt-2 flex flex-wrap items-center gap-2">
         <span
@@ -60,32 +74,157 @@ function ContactRow({
         {contact.nextFollowUp ? (
           <span className="text-xs text-amber-700">Follow-up {contact.nextFollowUp}</span>
         ) : null}
-        {contact.lastContacted ? (
-          <span className="text-xs text-stone-400">Last {contact.lastContacted}</span>
-        ) : null}
+        <span className="text-xs text-stone-400">Added {formatAddedDate(contact.createdAt)}</span>
       </div>
     </button>
   )
 }
 
-export function Contacts({
-  store,
-  contactStatuses,
-  stages,
-}: ContactsProps) {
-  const [view, setView] = useState<ContactView>('To Call Today')
+function SortHeader({
+  label,
+  sortKey,
+  activeKey,
+  direction,
+  onSort,
+}: {
+  label: string
+  sortKey: ContactSortKey
+  activeKey: ContactSortKey
+  direction: SortDirection
+  onSort: (key: ContactSortKey) => void
+}) {
+  const active = activeKey === sortKey
+  return (
+    <th className="px-4 py-3 font-semibold">
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className="inline-flex items-center gap-1 uppercase transition hover:text-stone-800"
+      >
+        {label}
+        {active ? <span aria-hidden>{direction === 'asc' ? '↑' : '↓'}</span> : null}
+      </button>
+    </th>
+  )
+}
+
+export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
+  const [filters, setFilters] = useState<ContactFilters>(DEFAULT_CONTACT_FILTERS)
+  const [searchDraft, setSearchDraft] = useState('')
   const [editing, setEditing] = useState<Contact | null>(null)
   const [creating, setCreating] = useState(false)
+  const [insightsOpen, setInsightsOpen] = useState(true)
+  const [sortKey, setSortKey] = useState<ContactSortKey>('contactName')
+  const [sortDir, setSortDir] = useState<SortDirection>('asc')
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      setFilters((f) => (f.search === searchDraft ? f : { ...f, search: searchDraft }))
+    }, 200)
+    return () => window.clearTimeout(id)
+  }, [searchDraft])
 
   const openContact = (c: Contact) => {
     setEditing(c)
     logViewEvent('contact.opened', c.id, c.contactName)
   }
 
-  const filtered = useMemo(() => {
-    const list = filterContacts(store.contacts, view)
-    return sortContactsForView(list, view)
-  }, [store.contacts, view])
+  const patchFilters = (patch: Partial<ContactFilters>) => {
+    setFilters((f) => ({ ...f, ...patch }))
+  }
+
+  const clearFilters = () => {
+    setSearchDraft('')
+    setFilters({ ...DEFAULT_CONTACT_FILTERS, queue: 'all' })
+  }
+
+  const statusOptions = useMemo(
+    () => (contactStatuses ?? []).map((s) => ({ value: s, label: s })),
+    [contactStatuses],
+  )
+
+  const stageOptions = useMemo(
+    () => (stages ?? []).map((s) => ({ value: s, label: s })),
+    [stages],
+  )
+
+  const companyOptions = useMemo(
+    () =>
+      [...store.companies]
+        .sort((a, b) => a.companyName.localeCompare(b.companyName))
+        .map((c) => ({ value: c.id, label: c.companyName })),
+    [store.companies],
+  )
+
+  const filtered = useMemo(
+    () => applyContactFilters(store.contacts, store.companies, filters),
+    [store.contacts, store.companies, filters],
+  )
+
+  const sorted = useMemo(() => {
+    const list = [...filtered]
+    const mul = sortDir === 'asc' ? 1 : -1
+    list.sort((a, b) => {
+      let cmp = 0
+      switch (sortKey) {
+        case 'contactName':
+          cmp = a.contactName.localeCompare(b.contactName)
+          break
+        case 'companyName': {
+          const an = store.getCompany(a.companyId)?.companyName ?? ''
+          const bn = store.getCompany(b.companyId)?.companyName ?? ''
+          cmp = an.localeCompare(bn)
+          break
+        }
+        case 'contactStatus':
+          cmp = a.contactStatus.localeCompare(b.contactStatus)
+          break
+        case 'stage': {
+          const as = store.getCompany(a.companyId)?.stage ?? ''
+          const bs = store.getCompany(b.companyId)?.stage ?? ''
+          cmp = as.localeCompare(bs)
+          break
+        }
+        case 'nextFollowUp':
+          cmp = (a.nextFollowUp ?? '9999-12-31').localeCompare(b.nextFollowUp ?? '9999-12-31')
+          break
+        case 'lastContacted':
+          cmp = (a.lastContacted ?? '').localeCompare(b.lastContacted ?? '')
+          break
+        case 'createdAt':
+          cmp = a.createdAt.localeCompare(b.createdAt)
+          break
+        default:
+          cmp = a.contactName.localeCompare(b.contactName)
+      }
+      if (cmp !== 0) return cmp * mul
+      return a.contactName.localeCompare(b.contactName)
+    })
+    return list
+  }, [filtered, sortKey, sortDir, store])
+
+  const insights = useMemo(
+    () => buildContactInsights(filtered, store.companies),
+    [filtered, store.companies],
+  )
+
+  const filtersActive = contactFiltersAreActive(filters)
+
+  const onSort = (key: ContactSortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir(key === 'createdAt' || key === 'lastContacted' ? 'desc' : 'asc')
+    }
+  }
+
+  const queueLabel =
+    CONTACT_QUEUE_OPTIONS.find((o) => o.value === filters.queue)?.label ?? 'All'
+  const dateLabel =
+    CONTACT_DATE_RANGE_OPTIONS.find((o) => o.value === filters.dateRange)?.label ?? 'All Time'
+  const companyLabel =
+    companyOptions.find((o) => o.value === filters.companyId)?.label ?? null
 
   return (
     <div className="space-y-4">
@@ -98,7 +237,7 @@ export function Contacts({
             Contacts
           </h1>
           <p className="mt-1 text-sm text-stone-500">
-            Work your call queue. Update status and follow-up date after every dial.
+            Search and filter your call queue. Track how new leads progress by period.
           </p>
         </div>
         <button type="button" className={btnPrimary} onClick={() => setCreating(true)}>
@@ -106,75 +245,322 @@ export function Contacts({
         </button>
       </header>
 
-      <div className="space-y-3">
-        {CONTACT_VIEW_GROUPS.map((group) => (
-          <div key={group.label}>
-            <p className="mb-1.5 text-[10px] font-semibold tracking-wide text-stone-400 uppercase">
-              {group.label}
-            </p>
-            <div className="flex gap-1.5 overflow-x-auto pb-1 kanban-scroll">
-              {group.views.map((v) => {
-                const count = filterContacts(store.contacts, v).length
-                return (
-                  <button
-                    key={v}
-                    type="button"
-                    onClick={() => setView(v)}
-                    className={`shrink-0 rounded-none px-3 py-1.5 text-xs font-medium transition ${
-                      view === v
-                        ? 'bg-teal-700 text-white'
-                        : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
-                    }`}
-                  >
-                    {v}
-                    <span className="ml-1.5 opacity-70">({count})</span>
-                  </button>
-                )
-              })}
-            </div>
-          </div>
-        ))}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <SearchInput
+          data-testid="contact-search"
+          value={searchDraft}
+          onChange={setSearchDraft}
+          placeholder="Search contacts, companies, emails…"
+        />
+        <FilterDropdown
+          data-testid="contact-date-range"
+          label="Added"
+          value={filters.dateRange}
+          options={CONTACT_DATE_RANGE_OPTIONS}
+          active={filters.dateRange !== 'all'}
+          onChange={(v) => patchFilters({ dateRange: v as ContactFilters['dateRange'] })}
+        />
       </div>
 
-      <p className="rounded-none bg-teal-50/80 px-3 py-2 text-xs text-teal-900/80">
-        <span className="font-semibold">{view}</span>
-        {' — '}
-        {CONTACT_VIEW_HINTS[view]}
-        {filtered.length > 0 ? (
-          <span className="text-teal-700"> · {filtered.length} contact{filtered.length === 1 ? '' : 's'}</span>
+      <div className="flex gap-1.5 overflow-x-auto pb-1 kanban-scroll">
+        <FilterDropdown
+          data-testid="contact-filter-queue"
+          label="Queue"
+          value={filters.queue}
+          options={CONTACT_QUEUE_OPTIONS}
+          active={filters.queue !== 'all'}
+          onChange={(v) => patchFilters({ queue: v as ContactFilters['queue'] })}
+        />
+        <FilterDropdown
+          data-testid="contact-filter-status"
+          label="Status"
+          value={filters.statuses}
+          options={statusOptions}
+          multi
+          active={filters.statuses.length > 0}
+          onChange={(v) => patchFilters({ statuses: v as string[] })}
+        />
+        <FilterDropdown
+          data-testid="contact-filter-company"
+          label="Company"
+          value={filters.companyId ?? ''}
+          options={[{ value: '', label: 'All companies' }, ...companyOptions]}
+          searchable
+          active={!!filters.companyId}
+          onChange={(v) =>
+            patchFilters({ companyId: !v || v === '' ? null : (v as string) })
+          }
+        />
+        <FilterDropdown
+          data-testid="contact-filter-stage"
+          label="Stage"
+          value={filters.stages}
+          options={stageOptions}
+          multi
+          active={filters.stages.length > 0}
+          onChange={(v) => patchFilters({ stages: v as string[] })}
+        />
+        <button
+          type="button"
+          data-testid="contact-filter-champion"
+          onClick={() => patchFilters({ championOnly: !filters.championOnly })}
+          className={`shrink-0 rounded-none px-3 py-1.5 text-xs font-medium transition ${
+            filters.championOnly
+              ? 'bg-teal-700 text-white'
+              : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
+          }`}
+        >
+          Champion only
+        </button>
+      </div>
+
+      {filtersActive ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {filters.search.trim() ? (
+            <FilterChip
+              label={`Search: ${filters.search.trim()}`}
+              onClear={() => {
+                setSearchDraft('')
+                patchFilters({ search: '' })
+              }}
+            />
+          ) : null}
+          {filters.queue !== 'all' ? (
+            <FilterChip label={`Queue: ${queueLabel}`} onClear={() => patchFilters({ queue: 'all' })} />
+          ) : null}
+          {filters.statuses.map((s) => (
+            <FilterChip
+              key={s}
+              label={`Status: ${s}`}
+              onClear={() =>
+                patchFilters({ statuses: filters.statuses.filter((x) => x !== s) })
+              }
+            />
+          ))}
+          {companyLabel ? (
+            <FilterChip
+              label={`Company: ${companyLabel}`}
+              onClear={() => patchFilters({ companyId: null })}
+            />
+          ) : null}
+          {filters.stages.map((s) => (
+            <FilterChip
+              key={s}
+              label={`Stage: ${s}`}
+              onClear={() =>
+                patchFilters({ stages: filters.stages.filter((x) => x !== s) })
+              }
+            />
+          ))}
+          {filters.championOnly ? (
+            <FilterChip
+              label="Champion only"
+              onClear={() => patchFilters({ championOnly: false })}
+            />
+          ) : null}
+          {filters.dateRange !== 'all' ? (
+            <FilterChip
+              label={`Added: ${dateLabel}`}
+              onClear={() => patchFilters({ dateRange: 'all' })}
+            />
+          ) : null}
+          <button
+            type="button"
+            data-testid="contact-clear-filters"
+            onClick={clearFilters}
+            className="text-xs font-medium text-teal-800 underline-offset-2 hover:underline"
+          >
+            Clear all filters
+          </button>
+        </div>
+      ) : null}
+
+      <section
+        data-testid="lead-insights"
+        className="rounded-none border border-[var(--color-line)] bg-[var(--color-panel)]"
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-[var(--color-line)] px-3 py-2">
+          <div>
+            <p className="text-[10px] font-semibold tracking-wide text-stone-400 uppercase">
+              Lead insights
+            </p>
+            <p className="text-xs text-stone-600">
+              {dateLabel}
+              {filters.queue !== 'all' ? ` · ${queueLabel}` : ''}
+              {' · '}
+              {insights.total} contact{insights.total === 1 ? '' : 's'}
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="lead-insights-toggle"
+            onClick={() => setInsightsOpen((v) => !v)}
+            className="text-xs font-medium text-stone-500 hover:text-stone-800"
+          >
+            {insightsOpen ? 'Collapse' : 'Expand'}
+          </button>
+        </div>
+        {insightsOpen ? (
+          <div className="space-y-3 px-3 py-3">
+            <div className="flex flex-wrap gap-2">
+              <span
+                data-testid="insight-total"
+                className="rounded-none bg-stone-100 px-2 py-1 text-[11px] font-medium text-stone-800"
+              >
+                {insights.total} leads
+              </span>
+              <span
+                data-testid="insight-contacted"
+                className="rounded-none bg-emerald-50 px-2 py-1 text-[11px] font-medium text-emerald-800"
+              >
+                {insights.contacted} contacted
+              </span>
+              <span
+                data-testid="insight-not-contacted"
+                className="rounded-none bg-sky-50 px-2 py-1 text-[11px] font-medium text-sky-800"
+              >
+                {insights.notContacted} not contacted
+              </span>
+              <span
+                data-testid="insight-not-reachable"
+                className="rounded-none bg-stone-200 px-2 py-1 text-[11px] font-medium text-stone-700"
+              >
+                {insights.notReachable} not reachable
+              </span>
+              <span
+                data-testid="insight-discoveries"
+                className="rounded-none bg-violet-50 px-2 py-1 text-[11px] font-medium text-violet-800"
+              >
+                {insights.discoveriesBooked} discoveries booked
+              </span>
+              <span
+                data-testid="insight-demos"
+                className="rounded-none bg-teal-50 px-2 py-1 text-[11px] font-medium text-teal-800"
+              >
+                {insights.demos} demos
+              </span>
+            </div>
+
+            {insights.statusCounts.length > 0 ? (
+              <div>
+                <p className="mb-1.5 text-[10px] font-semibold tracking-wide text-stone-400 uppercase">
+                  Contact status
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {insights.statusCounts.slice(0, 6).map(({ status, count }) => (
+                    <span
+                      key={status}
+                      className={`rounded-none px-2 py-0.5 text-[11px] font-medium ${statusColor(status)}`}
+                    >
+                      {count} {status}
+                    </span>
+                  ))}
+                  {insights.statusCounts.length > 6 ? (
+                    <span className="text-[11px] text-stone-400">
+                      +{insights.statusCounts.length - 6} more
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            ) : null}
+
+            {insights.companyStageCounts.length > 0 ? (
+              <div>
+                <p className="mb-1.5 text-[10px] font-semibold tracking-wide text-stone-400 uppercase">
+                  Company stages ({insights.uniqueCompanies} companies)
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {insights.companyStageCounts.map(({ stage, count }) => (
+                    <span
+                      key={stage}
+                      className="rounded-none bg-white px-2 py-0.5 text-[11px] font-medium text-stone-700 ring-1 ring-[var(--color-line)]"
+                    >
+                      {count} {stage}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
         ) : null}
+      </section>
+
+      <p className="text-xs text-stone-500">
+        Showing <span className="font-semibold text-stone-700">{sorted.length}</span> contact
+        {sorted.length === 1 ? '' : 's'}
       </p>
 
       <div className="space-y-3 md:hidden">
-        {filtered.map((t) => (
-          <ContactRow
-            key={t.id}
-            contact={t}
-            companyName={store.getCompany(t.companyId)?.companyName ?? '—'}
-            onEdit={() => openContact(t)}
-          />
-        ))}
-        {filtered.length === 0 ? (
-          <p className="py-10 text-center text-sm text-stone-400">No contacts in this view.</p>
+        {sorted.map((t) => {
+          const company = store.getCompany(t.companyId)
+          return (
+            <ContactRow
+              key={t.id}
+              contact={t}
+              companyName={company?.companyName ?? '—'}
+              stage={company?.stage ?? ''}
+              onEdit={() => openContact(t)}
+            />
+          )
+        })}
+        {sorted.length === 0 ? (
+          <p className="py-10 text-center text-sm text-stone-400">No contacts match these filters.</p>
         ) : null}
       </div>
 
       <div className="hidden overflow-hidden rounded-none border border-[var(--color-line)] bg-[var(--color-panel)] md:block">
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[800px] text-left text-sm">
+          <table className="w-full min-w-[960px] text-left text-sm">
             <thead>
-              <tr className="border-b border-[var(--color-line)] bg-stone-50/80 text-[11px] tracking-wide text-stone-500 uppercase">
-                <th className="px-4 py-3 font-semibold">Contact</th>
-                <th className="px-4 py-3 font-semibold">Company</th>
-                <th className="px-4 py-3 font-semibold">Role</th>
-                <th className="px-4 py-3 font-semibold">Status</th>
-                <th className="px-4 py-3 font-semibold">Phone</th>
-                <th className="px-4 py-3 font-semibold">Follow-up</th>
-                <th className="px-4 py-3 font-semibold">Last contacted</th>
+              <tr className="border-b border-[var(--color-line)] bg-stone-50/80 text-[11px] tracking-wide text-stone-500">
+                <SortHeader
+                  label="Contact"
+                  sortKey="contactName"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onSort={onSort}
+                />
+                <SortHeader
+                  label="Company"
+                  sortKey="companyName"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onSort={onSort}
+                />
+                <th className="px-4 py-3 font-semibold uppercase">Role</th>
+                <SortHeader
+                  label="Status"
+                  sortKey="contactStatus"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onSort={onSort}
+                />
+                <SortHeader
+                  label="Stage"
+                  sortKey="stage"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onSort={onSort}
+                />
+                <th className="px-4 py-3 font-semibold uppercase">Phone</th>
+                <SortHeader
+                  label="Follow-up"
+                  sortKey="nextFollowUp"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onSort={onSort}
+                />
+                <SortHeader
+                  label="Added"
+                  sortKey="createdAt"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onSort={onSort}
+                />
               </tr>
             </thead>
             <tbody>
-              {filtered.map((t) => {
+              {sorted.map((t) => {
                 const company = store.getCompany(t.companyId)
                 return (
                   <tr
@@ -206,16 +592,19 @@ export function Contacts({
                         {t.contactStatus}
                       </span>
                     </td>
+                    <td className="px-4 py-3 text-stone-600">{company?.stage ?? '—'}</td>
                     <td className="px-4 py-3 text-stone-600">{t.phone || '—'}</td>
                     <td className="px-4 py-3 text-stone-500">{t.nextFollowUp || '—'}</td>
-                    <td className="px-4 py-3 text-stone-500">{t.lastContacted || '—'}</td>
+                    <td className="px-4 py-3 text-stone-500">
+                      {formatAddedDate(t.createdAt)}
+                    </td>
                   </tr>
                 )
               })}
-              {filtered.length === 0 ? (
+              {sorted.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="px-4 py-10 text-center text-sm text-stone-400">
-                    No contacts in this view.
+                  <td colSpan={8} className="px-4 py-10 text-center text-sm text-stone-400">
+                    No contacts match these filters.
                   </td>
                 </tr>
               ) : null}

--- a/src/components/Contacts.tsx
+++ b/src/components/Contacts.tsx
@@ -262,7 +262,7 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
         />
       </div>
 
-      <div className="flex gap-1.5 overflow-x-auto pb-1 kanban-scroll">
+      <div className="flex flex-wrap gap-1.5 pb-1">
         <FilterDropdown
           data-testid="contact-filter-queue"
           label="Queue"

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 
 interface ModalProps {
@@ -85,3 +85,212 @@ export const btnPrimary =
 
 export const btnGhost =
   'inline-flex items-center justify-center rounded-none border border-[var(--color-line)] bg-white px-3 py-2 text-sm font-medium text-stone-700 transition hover:bg-stone-50'
+
+interface SearchInputProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  'data-testid'?: string
+}
+
+export function SearchInput({
+  value,
+  onChange,
+  placeholder = 'Search…',
+  'data-testid': testId,
+}: SearchInputProps) {
+  return (
+    <div className="relative min-w-0 flex-1">
+      <span
+        aria-hidden
+        className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-stone-400"
+      >
+        ⌕
+      </span>
+      <input
+        type="search"
+        data-testid={testId}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') onChange('')
+        }}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        className={`${inputClass} pl-9`}
+      />
+    </div>
+  )
+}
+
+interface FilterOption {
+  value: string
+  label: string
+}
+
+interface FilterDropdownProps {
+  label: string
+  value: string | string[]
+  options: FilterOption[]
+  multi?: boolean
+  searchable?: boolean
+  active?: boolean
+  onChange: (value: string | string[]) => void
+  'data-testid'?: string
+}
+
+export function FilterDropdown({
+  label,
+  value,
+  options,
+  multi = false,
+  searchable = false,
+  active = false,
+  onChange,
+  'data-testid': testId,
+}: FilterDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const rootRef = useRef<HTMLDivElement>(null)
+  const selected = Array.isArray(value) ? value : [String(value)]
+
+  useEffect(() => {
+    if (!open) return
+    const onDoc = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDoc)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const filtered = searchable
+    ? options.filter((o) => o.label.toLowerCase().includes(query.trim().toLowerCase()))
+    : options
+
+  const summary = (() => {
+    if (multi) {
+      if (selected.length === 0) return 'All'
+      if (selected.length === 1) {
+        return options.find((o) => o.value === selected[0])?.label ?? '1 selected'
+      }
+      return `${selected.length} selected`
+    }
+    return options.find((o) => o.value === (value as string))?.label ?? 'All'
+  })()
+
+  const toggle = (optValue: string) => {
+    if (multi) {
+      const next = selected.includes(optValue)
+        ? selected.filter((v) => v !== optValue)
+        : [...selected, optValue]
+      onChange(next)
+      return
+    }
+    onChange(optValue)
+    setOpen(false)
+  }
+
+  return (
+    <div ref={rootRef} className="relative shrink-0">
+      <button
+        type="button"
+        data-testid={testId}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        onClick={() => setOpen((v) => !v)}
+        className={`inline-flex items-center gap-1.5 rounded-none px-3 py-1.5 text-xs font-medium transition ${
+          active
+            ? 'bg-teal-700 text-white'
+            : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
+        }`}
+      >
+        <span className="opacity-70">{label}:</span>
+        <span>{summary}</span>
+        <span aria-hidden className="opacity-60">
+          ▾
+        </span>
+      </button>
+      {open ? (
+        <div
+          role="listbox"
+          aria-multiselectable={multi || undefined}
+          className="absolute top-full left-0 z-30 mt-1 max-h-64 w-64 overflow-auto border border-[var(--color-line)] bg-white shadow-sm"
+        >
+          {searchable ? (
+            <div className="sticky top-0 border-b border-[var(--color-line)] bg-white p-2">
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search…"
+                className={`${inputClass} py-1.5 text-xs`}
+                autoFocus
+              />
+            </div>
+          ) : null}
+          {filtered.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-stone-400">No matches</p>
+          ) : (
+            filtered.map((opt) => {
+              const isOn = selected.includes(opt.value)
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="option"
+                  aria-selected={isOn}
+                  onClick={() => toggle(opt.value)}
+                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition hover:bg-teal-50 ${
+                    isOn ? 'bg-teal-50/80 font-medium text-teal-900' : 'text-stone-700'
+                  }`}
+                >
+                  {multi ? (
+                    <span
+                      aria-hidden
+                      className={`inline-flex h-3.5 w-3.5 items-center justify-center border text-[9px] ${
+                        isOn
+                          ? 'border-teal-700 bg-teal-700 text-white'
+                          : 'border-stone-300 bg-white'
+                      }`}
+                    >
+                      {isOn ? '✓' : ''}
+                    </span>
+                  ) : null}
+                  <span className="min-w-0 truncate">{opt.label}</span>
+                </button>
+              )
+            })
+          )}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+interface FilterChipProps {
+  label: string
+  onClear: () => void
+}
+
+export function FilterChip({ label, onClear }: FilterChipProps) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-none bg-teal-50 px-2 py-1 text-[11px] font-medium text-teal-900 ring-1 ring-teal-200">
+      {label}
+      <button
+        type="button"
+        onClick={onClear}
+        aria-label={`Clear ${label}`}
+        className="text-teal-700 hover:text-teal-950"
+      >
+        ×
+      </button>
+    </span>
+  )
+}

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useId, useRef, useState } from 'react'
-import type { ReactNode } from 'react'
+import { useEffect, useId, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import type { CSSProperties, ReactNode } from 'react'
 
 interface ModalProps {
   open: boolean
@@ -151,23 +152,71 @@ export function FilterDropdown({
 }: FilterDropdownProps) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
+  const [panelStyle, setPanelStyle] = useState<CSSProperties>({})
   const rootRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
   const selected = Array.isArray(value) ? value : [String(value)]
+
+  const updatePosition = () => {
+    const btn = buttonRef.current
+    if (!btn) return
+    const rect = btn.getBoundingClientRect()
+    const width = Math.max(rect.width, 256)
+    const spaceBelow = window.innerHeight - rect.bottom
+    const openUp = spaceBelow < 280 && rect.top > spaceBelow
+    const maxHeight = Math.min(256, openUp ? rect.top - 12 : spaceBelow - 12)
+    let left = rect.left
+    if (left + width > window.innerWidth - 8) {
+      left = Math.max(8, window.innerWidth - width - 8)
+    }
+    setPanelStyle({
+      position: 'fixed',
+      left,
+      width,
+      maxHeight: Math.max(120, maxHeight),
+      zIndex: 80,
+      ...(openUp
+        ? { bottom: window.innerHeight - rect.top + 4 }
+        : { top: rect.bottom + 4 }),
+    })
+  }
+
+  useLayoutEffect(() => {
+    if (!open) return
+    updatePosition()
+  }, [open, options.length, query])
 
   useEffect(() => {
     if (!open) return
     const onDoc = (e: MouseEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+      const target = e.target as Node
+      if (rootRef.current?.contains(target)) return
+      if (panelRef.current?.contains(target)) return
+      setOpen(false)
     }
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setOpen(false)
     }
-    document.addEventListener('mousedown', onDoc)
+    const onReposition = () => updatePosition()
+    // Defer outside-close so the opening click never immediately closes the panel.
+    const timer = window.setTimeout(() => {
+      document.addEventListener('mousedown', onDoc)
+    }, 0)
     document.addEventListener('keydown', onKey)
+    window.addEventListener('resize', onReposition)
+    window.addEventListener('scroll', onReposition, true)
     return () => {
+      window.clearTimeout(timer)
       document.removeEventListener('mousedown', onDoc)
       document.removeEventListener('keydown', onKey)
+      window.removeEventListener('resize', onReposition)
+      window.removeEventListener('scroll', onReposition, true)
     }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) setQuery('')
   }, [open])
 
   const filtered = searchable
@@ -197,14 +246,80 @@ export function FilterDropdown({
     setOpen(false)
   }
 
+  const panel =
+    open && typeof document !== 'undefined'
+      ? createPortal(
+          <div
+            ref={panelRef}
+            role="listbox"
+            data-testid={testId ? `${testId}-panel` : undefined}
+            aria-multiselectable={multi || undefined}
+            style={panelStyle}
+            className="overflow-auto border border-[var(--color-line)] bg-white shadow-lg"
+          >
+            {searchable ? (
+              <div className="sticky top-0 border-b border-[var(--color-line)] bg-white p-2">
+                <input
+                  type="search"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search…"
+                  className={`${inputClass} py-1.5 text-xs`}
+                  autoFocus
+                />
+              </div>
+            ) : null}
+            {filtered.length === 0 ? (
+              <p className="px-3 py-2 text-xs text-stone-400">No matches</p>
+            ) : (
+              filtered.map((opt) => {
+                const isOn = selected.includes(opt.value)
+                return (
+                  <button
+                    key={opt.value || '__all__'}
+                    type="button"
+                    role="option"
+                    aria-selected={isOn}
+                    onClick={() => toggle(opt.value)}
+                    className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition hover:bg-teal-50 ${
+                      isOn ? 'bg-teal-50/80 font-medium text-teal-900' : 'text-stone-700'
+                    }`}
+                  >
+                    {multi ? (
+                      <span
+                        aria-hidden
+                        className={`inline-flex h-3.5 w-3.5 items-center justify-center border text-[9px] ${
+                          isOn
+                            ? 'border-teal-700 bg-teal-700 text-white'
+                            : 'border-stone-300 bg-white'
+                        }`}
+                      >
+                        {isOn ? '✓' : ''}
+                      </span>
+                    ) : null}
+                    <span className="min-w-0 truncate">{opt.label}</span>
+                  </button>
+                )
+              })
+            )}
+          </div>,
+          document.body,
+        )
+      : null
+
   return (
     <div ref={rootRef} className="relative shrink-0">
       <button
+        ref={buttonRef}
         type="button"
         data-testid={testId}
         aria-expanded={open}
         aria-haspopup="listbox"
-        onClick={() => setOpen((v) => !v)}
+        onClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          setOpen((v) => !v)
+        }}
         className={`inline-flex items-center gap-1.5 rounded-none px-3 py-1.5 text-xs font-medium transition ${
           active
             ? 'bg-teal-700 text-white'
@@ -217,59 +332,7 @@ export function FilterDropdown({
           ▾
         </span>
       </button>
-      {open ? (
-        <div
-          role="listbox"
-          aria-multiselectable={multi || undefined}
-          className="absolute top-full left-0 z-30 mt-1 max-h-64 w-64 overflow-auto border border-[var(--color-line)] bg-white shadow-sm"
-        >
-          {searchable ? (
-            <div className="sticky top-0 border-b border-[var(--color-line)] bg-white p-2">
-              <input
-                type="search"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search…"
-                className={`${inputClass} py-1.5 text-xs`}
-                autoFocus
-              />
-            </div>
-          ) : null}
-          {filtered.length === 0 ? (
-            <p className="px-3 py-2 text-xs text-stone-400">No matches</p>
-          ) : (
-            filtered.map((opt) => {
-              const isOn = selected.includes(opt.value)
-              return (
-                <button
-                  key={opt.value}
-                  type="button"
-                  role="option"
-                  aria-selected={isOn}
-                  onClick={() => toggle(opt.value)}
-                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition hover:bg-teal-50 ${
-                    isOn ? 'bg-teal-50/80 font-medium text-teal-900' : 'text-stone-700'
-                  }`}
-                >
-                  {multi ? (
-                    <span
-                      aria-hidden
-                      className={`inline-flex h-3.5 w-3.5 items-center justify-center border text-[9px] ${
-                        isOn
-                          ? 'border-teal-700 bg-teal-700 text-white'
-                          : 'border-stone-300 bg-white'
-                      }`}
-                    >
-                      {isOn ? '✓' : ''}
-                    </span>
-                  ) : null}
-                  <span className="min-w-0 truncate">{opt.label}</span>
-                </button>
-              )
-            })
-          )}
-        </div>
-      ) : null}
+      {panel}
     </div>
   )
 }

--- a/src/lib/views.ts
+++ b/src/lib/views.ts
@@ -3,6 +3,10 @@ import type {
   Stage,
   ContactView,
   ContactStatus,
+  ContactFilters,
+  ContactDateRange,
+  ContactSortKey,
+  SortDirection,
   Company,
   Contact,
 } from '../types'
@@ -40,8 +44,8 @@ const NOT_ICP_DQ_STATUSES: ContactStatus[] = [
   'Connected - DQ Company (Bad Fit)',
 ]
 
-export function isoDateOffset(days: number): string {
-  const d = new Date()
+export function isoDateOffset(days: number, now = new Date()): string {
+  const d = new Date(now.getFullYear(), now.getMonth(), now.getDate())
   d.setDate(d.getDate() + days)
   const y = d.getFullYear()
   const m = String(d.getMonth() + 1).padStart(2, '0')
@@ -246,6 +250,280 @@ export function sortContactsForView(contacts: Contact[], view: ContactView): Con
     default:
       return sorted.sort((a, b) => a.contactName.localeCompare(b.contactName))
   }
+}
+
+export const DEFAULT_CONTACT_FILTERS: ContactFilters = {
+  search: '',
+  queue: 'to-call-today',
+  statuses: [],
+  companyId: null,
+  stages: [],
+  championOnly: false,
+  dateRange: 'all',
+}
+
+export const CONTACT_QUEUE_OPTIONS: { value: ContactFilters['queue']; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'to-call-today', label: 'To Call Today' },
+  { value: 'follow-up-today', label: 'Follow-up Today' },
+  { value: 'overdue', label: 'Overdue' },
+  { value: 'didnt-pick-yesterday', label: "Didn't Pick Yesterday" },
+]
+
+export const CONTACT_DATE_RANGE_OPTIONS: { value: ContactDateRange; label: string }[] = [
+  { value: 'all', label: 'All Time' },
+  { value: 'this-week', label: 'This Week' },
+  { value: 'this-month', label: 'This Month' },
+  { value: 'last-30-days', label: 'Last 30 Days' },
+]
+
+/** Monday 00:00 local of the current week as ISO date `YYYY-MM-DD`. */
+export function startOfWeekIso(now = new Date()): string {
+  const d = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const day = d.getDay()
+  const mondayOffset = day === 0 ? -6 : 1 - day
+  d.setDate(d.getDate() + mondayOffset)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const dayNum = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${dayNum}`
+}
+
+/** First day of the current month as ISO date `YYYY-MM-DD`. */
+export function startOfMonthIso(now = new Date()): string {
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  return `${y}-${m}-01`
+}
+
+/** Inclusive lower bound for `contact.createdAt` comparisons, or null when unrestricted. */
+export function dateRangeStartIso(range: ContactDateRange, now = new Date()): string | null {
+  switch (range) {
+    case 'all':
+      return null
+    case 'this-week':
+      return startOfWeekIso(now)
+    case 'this-month':
+      return startOfMonthIso(now)
+    case 'last-30-days':
+      return isoDateOffset(-30, now)
+    default:
+      return null
+  }
+}
+
+function createdAtDate(iso: string): string {
+  return iso.slice(0, 10)
+}
+
+function matchesQueue(contact: Contact, queue: ContactFilters['queue']): boolean {
+  if (queue === 'all') return true
+  const today = todayIso()
+  const yesterday = yesterdayIso()
+  switch (queue) {
+    case 'to-call-today':
+      if (!isActiveContact(contact)) return false
+      if (contact.contactStatus === 'Not Contacted') return true
+      if (contact.nextFollowUp && contact.nextFollowUp <= today) return true
+      if (
+        isDidntPick(contact.contactStatus) &&
+        contact.lastContacted &&
+        contact.lastContacted <= yesterday
+      ) {
+        return true
+      }
+      return false
+    case 'follow-up-today':
+      return isActiveContact(contact) && contact.nextFollowUp === today
+    case 'overdue':
+      return isActiveContact(contact) && !!contact.nextFollowUp && contact.nextFollowUp < today
+    case 'didnt-pick-yesterday':
+      return isDidntPick(contact.contactStatus) && contact.lastContacted === yesterday
+    default:
+      return true
+  }
+}
+
+/**
+ * Composable Contacts-page filter (search + queue + status + company + stage +
+ * champion + createdAt date range). Companies are required for search/stage joins.
+ */
+export function applyContactFilters(
+  contacts: Contact[],
+  companies: Company[],
+  filters: ContactFilters,
+): Contact[] {
+  const companyById = new Map(companies.map((c) => [c.id, c]))
+  const search = filters.search.trim().toLowerCase()
+  const dateStart = dateRangeStartIso(filters.dateRange)
+
+  return contacts.filter((contact) => {
+    if (!matchesQueue(contact, filters.queue)) return false
+
+    if (filters.statuses.length > 0 && !filters.statuses.includes(contact.contactStatus)) {
+      return false
+    }
+
+    if (filters.companyId && contact.companyId !== filters.companyId) return false
+
+    if (filters.championOnly && !contact.champion) return false
+
+    if (dateStart && createdAtDate(contact.createdAt) < dateStart) return false
+
+    const company = contact.companyId ? companyById.get(contact.companyId) : undefined
+
+    if (filters.stages.length > 0) {
+      if (!company || !filters.stages.includes(company.stage)) return false
+    }
+
+    if (search) {
+      const haystack = [
+        contact.contactName,
+        contact.email,
+        contact.phone,
+        company?.companyName ?? '',
+      ]
+        .join(' ')
+        .toLowerCase()
+      if (!haystack.includes(search)) return false
+    }
+
+    return true
+  })
+}
+
+export function sortContactsByKey(
+  contacts: Contact[],
+  companies: Company[],
+  key: ContactSortKey,
+  direction: SortDirection,
+): Contact[] {
+  const companyById = new Map(companies.map((c) => [c.id, c]))
+  const mul = direction === 'asc' ? 1 : -1
+  const sorted = [...contacts]
+
+  sorted.sort((a, b) => {
+    let cmp = 0
+    switch (key) {
+      case 'contactName':
+        cmp = a.contactName.localeCompare(b.contactName)
+        break
+      case 'companyName': {
+        const an = companyById.get(a.companyId ?? '')?.companyName ?? ''
+        const bn = companyById.get(b.companyId ?? '')?.companyName ?? ''
+        cmp = an.localeCompare(bn)
+        break
+      }
+      case 'contactStatus':
+        cmp = a.contactStatus.localeCompare(b.contactStatus)
+        break
+      case 'stage': {
+        const as = companyById.get(a.companyId ?? '')?.stage ?? ''
+        const bs = companyById.get(b.companyId ?? '')?.stage ?? ''
+        cmp = as.localeCompare(bs)
+        break
+      }
+      case 'nextFollowUp':
+        cmp = (a.nextFollowUp ?? '9999-12-31').localeCompare(b.nextFollowUp ?? '9999-12-31')
+        break
+      case 'lastContacted':
+        cmp = (a.lastContacted ?? '').localeCompare(b.lastContacted ?? '')
+        break
+      case 'createdAt':
+        cmp = a.createdAt.localeCompare(b.createdAt)
+        break
+      default:
+        cmp = a.contactName.localeCompare(b.contactName)
+    }
+    if (cmp !== 0) return cmp * mul
+    return a.contactName.localeCompare(b.contactName)
+  })
+
+  return sorted
+}
+
+export interface ContactInsights {
+  total: number
+  contacted: number
+  notContacted: number
+  notReachable: number
+  discoveriesBooked: number
+  demos: number
+  statusCounts: { status: string; count: number }[]
+  uniqueCompanies: number
+  companyStageCounts: { stage: string; count: number }[]
+}
+
+const NOT_REACHABLE_STATUSES = new Set<ContactStatus>(["Didn't Pick", 'No Answer', 'Wrong/Bad Number'])
+const DISCOVERY_BOOKED_STATUS = 'Connected - Booked a Discovery Call'
+const DEMO_STAGES = new Set(['Demo Scheduled', 'Demo Delivered'])
+
+/** Aggregate lead insights for the (already filtered) contact list. */
+export function buildContactInsights(
+  contacts: Contact[],
+  companies: Company[],
+): ContactInsights {
+  const companyById = new Map(companies.map((c) => [c.id, c]))
+  const statusMap = new Map<string, number>()
+  const stageMap = new Map<string, number>()
+  const seenCompanies = new Set<string>()
+
+  let contacted = 0
+  let notContacted = 0
+  let notReachable = 0
+  let discoveriesBooked = 0
+  let demos = 0
+
+  for (const c of contacts) {
+    statusMap.set(c.contactStatus, (statusMap.get(c.contactStatus) ?? 0) + 1)
+
+    if (c.contactStatus === 'Not Contacted') notContacted += 1
+    else contacted += 1
+
+    if (NOT_REACHABLE_STATUSES.has(c.contactStatus)) notReachable += 1
+    if (c.contactStatus === DISCOVERY_BOOKED_STATUS) discoveriesBooked += 1
+
+    if (c.companyId && !seenCompanies.has(c.companyId)) {
+      seenCompanies.add(c.companyId)
+      const company = companyById.get(c.companyId)
+      if (company) {
+        stageMap.set(company.stage, (stageMap.get(company.stage) ?? 0) + 1)
+        if (DEMO_STAGES.has(company.stage)) demos += 1
+      }
+    }
+  }
+
+  const statusCounts = [...statusMap.entries()]
+    .map(([status, count]) => ({ status, count }))
+    .sort((a, b) => b.count - a.count)
+
+  const companyStageCounts = [...stageMap.entries()]
+    .map(([stage, count]) => ({ stage, count }))
+    .sort((a, b) => b.count - a.count)
+
+  return {
+    total: contacts.length,
+    contacted,
+    notContacted,
+    notReachable,
+    discoveriesBooked,
+    demos,
+    statusCounts,
+    uniqueCompanies: seenCompanies.size,
+    companyStageCounts,
+  }
+}
+
+export function contactFiltersAreActive(filters: ContactFilters): boolean {
+  return (
+    filters.search.trim() !== '' ||
+    filters.queue !== 'all' ||
+    filters.statuses.length > 0 ||
+    filters.companyId !== null ||
+    filters.stages.length > 0 ||
+    filters.championOnly ||
+    filters.dateRange !== 'all'
+  )
 }
 
 export function intentColor(intent: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,39 @@ export type ContactView =
   | 'Future Follow-up'
   | 'Rejected'
 
+/** Smart date-logic queue for the Contacts page — replaces the old "Today" tab group. */
+export type ContactQueue =
+  | 'all'
+  | 'to-call-today'
+  | 'follow-up-today'
+  | 'overdue'
+  | 'didnt-pick-yesterday'
+
+/** Time window applied to `contact.createdAt` for the Contacts page filter bar + lead insights. */
+export type ContactDateRange = 'all' | 'this-week' | 'this-month' | 'last-30-days'
+
+export type ContactSortKey =
+  | 'contactName'
+  | 'companyName'
+  | 'contactStatus'
+  | 'stage'
+  | 'nextFollowUp'
+  | 'lastContacted'
+  | 'createdAt'
+
+export type SortDirection = 'asc' | 'desc'
+
+/** Composable filter state for the Contacts page (search + dropdowns, replaces the 18-tab system). */
+export interface ContactFilters {
+  search: string
+  queue: ContactQueue
+  statuses: string[]
+  companyId: string | null
+  stages: string[]
+  championOnly: boolean
+  dateRange: ContactDateRange
+}
+
 /** One row from the daily prospect paste (Excel / Sheets / LinkedIn export). */
 export interface ProspectRow {
   company: string

--- a/testing/e2e/champion-sync.spec.ts
+++ b/testing/e2e/champion-sync.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
-import { loginAsFounder, navTo } from './helpers'
+import { loginAsFounder, navTo, showAllContacts } from './helpers'
 
 /**
  * Issue #29 — a champion contact's status change auto-moves its company on the Kanban,
@@ -64,7 +64,7 @@ async function addContact(
 
 async function openContact(page: Page, name: string) {
   await navTo(page, 'Contacts')
-  await page.getByRole('button', { name: /All Contacts/ }).click()
+  await showAllContacts(page)
   await page.locator('main table').getByText(name).first().click()
   await expect(page.getByRole('heading', { name })).toBeVisible()
 }

--- a/testing/e2e/clicks.spec.ts
+++ b/testing/e2e/clicks.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
-import { loginAsFounder, navTo } from './helpers'
+import { loginAsFounder, navTo, showAllContacts } from './helpers'
 
 /** Inner name button on a kanban card (not the outer dnd-kit drag handle). */
 function companyCard(page: Page, name: string | RegExp) {
@@ -89,14 +89,14 @@ test.describe('Click behaviours (UI)', () => {
     await page.getByLabel('Email', { exact: true }).fill(`click.${stamp}@seed.example`)
     await page.getByRole('button', { name: 'Add contact', exact: true }).click()
 
-    await page.getByRole('button', { name: /All Contacts/ }).click()
+    await showAllContacts(page)
     await expect(page.locator('main table').getByText(name)).toBeVisible()
   })
 
   test('editing a contact status updates the table', async ({ page }) => {
     await loginAsFounder(page)
     await navTo(page, 'Contacts')
-    await page.getByRole('button', { name: /All Contacts/ }).click()
+    await showAllContacts(page)
 
     await page.locator('main table').getByText('Jordan Sample').first().click()
     await expect(page.getByRole('heading', { name: 'Jordan Sample' })).toBeVisible()

--- a/testing/e2e/company-stage-history.spec.ts
+++ b/testing/e2e/company-stage-history.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
-import { loginAsFounder, navTo } from './helpers'
+import { loginAsFounder, navTo, showAllContacts } from './helpers'
 
 const cardSelector = (companyId: string) =>
   `[data-testid="company-card"][data-company-id="${companyId}"]`
@@ -40,7 +40,7 @@ async function addContact(
 
 async function openContact(page: Page, name: string) {
   await navTo(page, 'Contacts')
-  await page.getByRole('button', { name: /All Contacts/ }).click()
+  await showAllContacts(page)
   await page.locator('main table').getByText(name).first().click()
   await expect(page.getByRole('heading', { name })).toBeVisible()
 }

--- a/testing/e2e/contacts-filters.spec.ts
+++ b/testing/e2e/contacts-filters.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test'
+import { loginAsFounder, navTo, showAllContacts } from './helpers'
+
+/**
+ * Issue #41 — Contacts page search, composable filters, and lead insights strip.
+ */
+test.describe('Contacts search + filters + insights (issue #41)', () => {
+  test('search finds a contact by name and opens the detail modal', async ({ page }) => {
+    await loginAsFounder(page)
+    await navTo(page, 'Contacts')
+
+    const stamp = Date.now()
+    const name = `Search Target ${stamp}`
+    await page.getByRole('button', { name: '+ Add contact' }).click()
+    await expect(page.getByRole('heading', { name: 'Add contact' })).toBeVisible()
+    await page.getByLabel('Contact Name *').fill(name)
+    await page.locator('form select').first().selectOption({ label: 'Nova Health' })
+    await page.getByLabel('Email', { exact: true }).fill(`search.${stamp}@seed.example`)
+    await page.getByRole('button', { name: 'Add contact', exact: true }).click()
+    await expect(page.getByRole('heading', { name: 'Add contact' })).toHaveCount(0)
+
+    await showAllContacts(page)
+    await page.getByTestId('contact-search').fill(name)
+    await expect(page.locator('main table').getByText(name)).toBeVisible()
+    await expect(page.locator('main table').getByText('Alex Example')).toHaveCount(0)
+
+    await page.locator('main table').getByText(name).first().click()
+    await expect(page.getByRole('heading', { name })).toBeVisible()
+  })
+
+  test('status filter and clear-all reset the table', async ({ page }) => {
+    await loginAsFounder(page)
+    await navTo(page, 'Contacts')
+    await showAllContacts(page)
+
+    await page.getByTestId('contact-filter-status').click()
+    await page.getByRole('option', { name: 'Interested', exact: true }).click()
+    // Close the multi-select by clicking outside
+    await page.getByRole('heading', { name: 'Contacts' }).click()
+
+    await expect(page.getByTestId('contact-clear-filters')).toBeVisible()
+    await page.getByTestId('contact-clear-filters').click()
+    await expect(page.getByTestId('contact-clear-filters')).toHaveCount(0)
+  })
+
+  test('lead insights strip shows outcome totals for the filtered set', async ({ page }) => {
+    await loginAsFounder(page)
+    await navTo(page, 'Contacts')
+    await showAllContacts(page)
+
+    const insights = page.getByTestId('lead-insights')
+    await expect(insights).toBeVisible()
+    await expect(page.getByTestId('insight-total')).toBeVisible()
+    await expect(page.getByTestId('insight-contacted')).toBeVisible()
+    await expect(page.getByTestId('insight-not-contacted')).toBeVisible()
+    await expect(page.getByTestId('insight-discoveries')).toBeVisible()
+    await expect(page.getByTestId('insight-demos')).toBeVisible()
+
+    await page.getByTestId('lead-insights-toggle').click()
+    await expect(page.getByTestId('insight-total')).toHaveCount(0)
+    await page.getByTestId('lead-insights-toggle').click()
+    await expect(page.getByTestId('insight-total')).toBeVisible()
+  })
+
+  test('date range filter restricts contacts by createdAt', async ({ page }) => {
+    await loginAsFounder(page)
+    await navTo(page, 'Contacts')
+    await showAllContacts(page)
+
+    await page.getByTestId('contact-date-range').click()
+    await page.getByRole('option', { name: 'This Week', exact: true }).click()
+    await expect(page.getByTestId('contact-clear-filters')).toBeVisible()
+    await expect(page.getByTestId('insight-total')).toBeVisible()
+  })
+})

--- a/testing/e2e/crm-data.spec.ts
+++ b/testing/e2e/crm-data.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { loginAsFounder, navTo } from './helpers'
+import { loginAsFounder, navTo, showAllContacts } from './helpers'
 
 test.describe('CRM flows (UI)', () => {
   test('pipeline shows seeded companies', async ({ page }) => {
@@ -14,7 +14,7 @@ test.describe('CRM flows (UI)', () => {
     await loginAsFounder(page)
     await navTo(page, 'Contacts')
     await expect(page.getByRole('heading', { name: 'Contacts' })).toBeVisible()
-    await page.getByRole('button', { name: /All Contacts/ }).click()
+    await showAllContacts(page)
     await expect(page.locator('main table').getByText('Alex Example').first()).toBeVisible()
   })
 

--- a/testing/e2e/helpers.ts
+++ b/testing/e2e/helpers.ts
@@ -47,3 +47,12 @@ export async function loginAsSdr(page: Page) {
 export async function navTo(page: Page, label: string) {
   await page.locator('aside:visible').getByRole('button', { name: new RegExp(label) }).click()
 }
+
+/**
+ * Contacts page defaults to Queue = "To Call Today". Select Queue → All so the
+ * full table is visible (replaces the old "All Contacts" tab).
+ */
+export async function showAllContacts(page: Page) {
+  await page.getByTestId('contact-filter-queue').click()
+  await page.getByRole('option', { name: 'All', exact: true }).click()
+}

--- a/testing/unit/activityFieldChanges.test.ts
+++ b/testing/unit/activityFieldChanges.test.ts
@@ -4,7 +4,7 @@ import {
   formatFieldChangeSummary,
   noteSnippet,
   normalizeActivityValue,
-} from '../../server/activity'
+} from '../../server/activityFields'
 
 describe('activity field change helpers', () => {
   it('normalizes empty and dates', () => {

--- a/testing/unit/views.test.ts
+++ b/testing/unit/views.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { filterCompanies, filterContacts, todayIso, yesterdayIso } from '../../src/lib/views'
-import type { Company, Contact } from '../../src/types'
+import {
+  applyContactFilters,
+  buildContactInsights,
+  dateRangeStartIso,
+  filterCompanies,
+  filterContacts,
+  startOfMonthIso,
+  startOfWeekIso,
+  todayIso,
+  yesterdayIso,
+} from '../../src/lib/views'
+import type { Company, Contact, ContactFilters } from '../../src/types'
 
 function company(partial: Partial<Company> & Pick<Company, 'id' | 'companyName' | 'stage'>): Company {
   return {
@@ -40,6 +50,16 @@ function contact(
     ...partial,
   }
 }
+
+const baseFilters = (): ContactFilters => ({
+  search: '',
+  queue: 'all',
+  statuses: [],
+  companyId: null,
+  stages: [],
+  championOnly: false,
+  dateRange: 'all',
+})
 
 describe('filterCompanies', () => {
   const companies = [
@@ -107,5 +127,201 @@ describe('filterContacts', () => {
     expect(filterContacts(contacts, "Didn't Pick Yesterday").map((c) => c.id)).toEqual(['4'])
     expect(filterContacts(contacts, 'Champions').map((c) => c.id)).toEqual(['5'])
     expect(filterContacts(contacts, 'To Call Today').length).toBeGreaterThanOrEqual(3)
+  })
+})
+
+describe('applyContactFilters', () => {
+  const companies = [
+    company({ id: 'c1', companyName: 'Acme Health', stage: 'Lead Added' }),
+    company({ id: 'c2', companyName: 'Beta Labs', stage: 'Demo Scheduled' }),
+    company({ id: 'c3', companyName: 'Gamma Soft', stage: 'Follow-up' }),
+  ]
+
+  const contacts = [
+    contact({
+      id: '1',
+      companyId: 'c1',
+      contactName: 'Alice Fresh',
+      contactStatus: 'Not Contacted',
+      email: 'alice@acme.example',
+      phone: '+1 555 0100',
+      createdAt: '2026-07-20T10:00:00.000Z',
+    }),
+    contact({
+      id: '2',
+      companyId: 'c2',
+      contactName: 'Bob Interested',
+      contactStatus: 'Interested',
+      email: 'bob@beta.example',
+      champion: true,
+      createdAt: '2026-07-22T10:00:00.000Z',
+    }),
+    contact({
+      id: '3',
+      companyId: 'c2',
+      contactName: 'Cara Discovery',
+      contactStatus: 'Connected - Booked a Discovery Call',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    }),
+    contact({
+      id: '4',
+      companyId: 'c3',
+      contactName: 'Dan NoPick',
+      contactStatus: "Didn't Pick",
+      lastContacted: yesterdayIso(),
+      createdAt: '2026-07-24T10:00:00.000Z',
+    }),
+  ]
+
+  it('returns all contacts when filters are empty', () => {
+    expect(applyContactFilters(contacts, companies, baseFilters())).toHaveLength(4)
+  })
+
+  it('searches contact name, email, phone, and company name', () => {
+    expect(
+      applyContactFilters(contacts, companies, { ...baseFilters(), search: 'alice' }).map(
+        (c) => c.id,
+      ),
+    ).toEqual(['1'])
+    expect(
+      applyContactFilters(contacts, companies, { ...baseFilters(), search: 'beta labs' }).map(
+        (c) => c.id,
+      ),
+    ).toEqual(['2', '3'])
+    expect(
+      applyContactFilters(contacts, companies, { ...baseFilters(), search: '555 0100' }).map(
+        (c) => c.id,
+      ),
+    ).toEqual(['1'])
+  })
+
+  it('filters by queue, status, company, stage, and champion', () => {
+    expect(
+      applyContactFilters(contacts, companies, {
+        ...baseFilters(),
+        queue: 'to-call-today',
+      }).map((c) => c.id),
+    ).toContain('1')
+
+    expect(
+      applyContactFilters(contacts, companies, {
+        ...baseFilters(),
+        statuses: ['Interested'],
+      }).map((c) => c.id),
+    ).toEqual(['2'])
+
+    expect(
+      applyContactFilters(contacts, companies, {
+        ...baseFilters(),
+        companyId: 'c2',
+      }).map((c) => c.id),
+    ).toEqual(['2', '3'])
+
+    expect(
+      applyContactFilters(contacts, companies, {
+        ...baseFilters(),
+        stages: ['Demo Scheduled'],
+      }).map((c) => c.id),
+    ).toEqual(['2', '3'])
+
+    expect(
+      applyContactFilters(contacts, companies, {
+        ...baseFilters(),
+        championOnly: true,
+      }).map((c) => c.id),
+    ).toEqual(['2'])
+  })
+
+  it('composes multiple filters with AND logic', () => {
+    expect(
+      applyContactFilters(contacts, companies, {
+        ...baseFilters(),
+        companyId: 'c2',
+        statuses: ['Interested'],
+        championOnly: true,
+      }).map((c) => c.id),
+    ).toEqual(['2'])
+  })
+
+  it('filters by createdAt date range', () => {
+    const now = new Date('2026-07-25T12:00:00')
+    expect(dateRangeStartIso('this-week', now)).toBe(startOfWeekIso(now))
+    expect(dateRangeStartIso('this-month', now)).toBe(startOfMonthIso(now))
+    expect(dateRangeStartIso('last-30-days', now)).toBe('2026-06-25')
+    expect(dateRangeStartIso('all', now)).toBeNull()
+
+    // Patch dateRangeStartIso uses real "now" inside applyContactFilters —
+    // so for a deterministic test, pick contacts relative to todayIso().
+    const today = todayIso()
+    const recent = contact({
+      id: 'r1',
+      companyId: 'c1',
+      contactName: 'Recent',
+      contactStatus: 'Not Contacted',
+      createdAt: `${today}T08:00:00.000Z`,
+    })
+    const old = contact({
+      id: 'o1',
+      companyId: 'c1',
+      contactName: 'Old',
+      contactStatus: 'Not Contacted',
+      createdAt: '2020-01-01T00:00:00.000Z',
+    })
+    const result = applyContactFilters([recent, old], companies, {
+      ...baseFilters(),
+      dateRange: 'last-30-days',
+    })
+    expect(result.map((c) => c.id)).toEqual(['r1'])
+  })
+})
+
+describe('buildContactInsights', () => {
+  it('aggregates contacted, unreachable, discoveries, demos, and company stages', () => {
+    const companies = [
+      company({ id: 'c1', companyName: 'A', stage: 'Lead Added' }),
+      company({ id: 'c2', companyName: 'B', stage: 'Demo Scheduled' }),
+    ]
+    const contacts = [
+      contact({
+        id: '1',
+        companyId: 'c1',
+        contactName: 'A',
+        contactStatus: 'Not Contacted',
+      }),
+      contact({
+        id: '2',
+        companyId: 'c1',
+        contactName: 'B',
+        contactStatus: "Didn't Pick",
+      }),
+      contact({
+        id: '3',
+        companyId: 'c2',
+        contactName: 'C',
+        contactStatus: 'Connected - Booked a Discovery Call',
+      }),
+      contact({
+        id: '4',
+        companyId: 'c2',
+        contactName: 'D',
+        contactStatus: 'Interested',
+      }),
+    ]
+
+    const insights = buildContactInsights(contacts, companies)
+    expect(insights.total).toBe(4)
+    expect(insights.notContacted).toBe(1)
+    expect(insights.contacted).toBe(3)
+    expect(insights.notReachable).toBe(1)
+    expect(insights.discoveriesBooked).toBe(1)
+    expect(insights.demos).toBe(1)
+    expect(insights.uniqueCompanies).toBe(2)
+    expect(insights.companyStageCounts).toEqual(
+      expect.arrayContaining([
+        { stage: 'Lead Added', count: 1 },
+        { stage: 'Demo Scheduled', count: 1 },
+      ]),
+    )
+    expect(insights.statusCounts[0]?.count).toBeGreaterThanOrEqual(1)
   })
 })


### PR DESCRIPTION
## Summary
- Replaces the 18-tab Contacts filter system with a search bar + composable filter dropdowns (Queue, Status, Company, Stage, Champion, Added date range)
- Adds a collapsible **Lead insights** strip scoped to the current filters / date range: leads added, contacted vs not contacted, not reachable, discoveries booked, demos, status breakdown, and linked company stage distribution
- Enhances the contacts table with Stage + Added columns and sortable headers
- Closes #41

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (unit — 66 passed)
- [x] `npm run build`
- [x] `npm run test:api` (functional — 31 passed)
- [x] `npm run test:e2e` (31 passed, including new `contacts-filters.spec.ts`)
- [ ] Manual: open Contacts → search by name/company → apply Queue + Status + This Week → confirm insights strip matches the filtered set → click a row → modal opens


Made with [Cursor](https://cursor.com)