### PR TITLE
feat: add activity export as CSV/JSON [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -65,6 +65,7 @@ Requires AWS env vars. See `.env.example`.
 | `POST` | `/api/activity/events` | Client-side activity event |
 | `GET` | `/api/activity/overview` | Manager overview |
 | `GET` | `/api/activity/timeline` | Event timeline |
+| `GET` | `/api/activity/export` | Export activity events as CSV or JSON. Query: `format=csv|json`, `from`, `to`, `userId`. Admin/founder only. |
 | `GET` | `/api/activity/company/:id/history` | Company progress (company + linked contact events) |
 | `GET` | `/api/activity/lead/:entityType/:id` | Lead-centric activity |
 

--- a/server/activityRoutes.ts
+++ b/server/activityRoutes.ts
@@ -425,6 +425,70 @@ export function registerActivityRoutes(app: Express) {
     })
   })
 
+  app.get('/api/activity/export', requireAuth, requireAdmin, async (req, res) => {
+    const format = String(req.query.format ?? 'json').toLowerCase()
+    if (format !== 'csv' && format !== 'json') {
+      res.status(400).json({ error: 'format must be csv or json' })
+      return
+    }
+    const userFilter = parseUserFilter(req)
+    if (!userFilter) {
+      res.status(400).json({ error: 'userId query required (uuid or all)' })
+      return
+    }
+    const { from, to, start, end } = parseDateRange(req)
+    const allUsers = await listSdrUsers()
+    const selected =
+      userFilter === 'all' ? allUsers.filter((u) => u.role === 'sdr') : allUsers.filter((u) => u.id === userFilter)
+    const userIds = selected.map((u) => u.id)
+    const events = await loadEvents(userIds, start, end, '')
+
+    if (format === 'csv') {
+      const header = 'id,user_id,user_name,event_type,entity_type,entity_id,summary,created_at\n'
+      const rows = events
+        .map((e) => {
+          const escape = (v: unknown) => {
+            const s = String(v ?? '')
+            return s.includes(',') || s.includes('"') || s.includes('\n') ? `"${s.replace(/"/g, '""')}"` : s
+          }
+          return [
+            escape(e.id),
+            escape(e.user_id),
+            escape(e.user_name),
+            escape(e.event_type),
+            escape(e.entity_type),
+            escape(e.entity_id),
+            escape(e.summary),
+            escape(new Date(String(e.created_at)).toISOString()),
+          ].join(',')
+        })
+        .join('\n')
+      const filename = `activity_export_${from}_${to}.csv`
+      res.setHeader('Content-Type', 'text/csv')
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`)
+      res.send(header + rows)
+    } else {
+      const filename = `activity_export_${from}_${to}.json`
+      res.setHeader('Content-Type', 'application/json')
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`)
+      res.json({
+        from,
+        to,
+        exportedAt: new Date().toISOString(),
+        events: events.map((e) => ({
+          id: String(e.id),
+          userId: String(e.user_id),
+          userName: String(e.user_name),
+          eventType: String(e.event_type),
+          entityType: String(e.entity_type),
+          entityId: e.entity_id ? String(e.entity_id) : null,
+          summary: String(e.summary),
+          createdAt: new Date(String(e.created_at)).toISOString(),
+        })),
+      })
+    }
+  })
+
   app.get('/api/activity/timeline', requireAuth, requireAdmin, async (req, res) => {
     const userFilter = parseUserFilter(req)
     if (!userFilter) {

--- a/src/components/SdrActivity.tsx
+++ b/src/components/SdrActivity.tsx
@@ -5,6 +5,7 @@ import {
   fetchSdrs,
   fetchTimeline,
   todayIstIso,
+  buildExportUrl,
   type ActivityOverview,
   type ActivitySdr,
   type TimelineEvent,
@@ -253,6 +254,30 @@ export function SdrActivity() {
           <button type="button" className={btnGhost} onClick={() => void load()} disabled={loading}>
             Refresh
           </button>
+          <span className="flex items-center gap-1">
+            <button
+              type="button"
+              className={btnGhost}
+              onClick={() => {
+                const url = buildExportUrl({ from, to, userId, format: 'csv' })
+                window.open(url, '_blank')
+              }}
+              disabled={loading}
+            >
+              CSV
+            </button>
+            <button
+              type="button"
+              className={btnGhost}
+              onClick={() => {
+                const url = buildExportUrl({ from, to, userId, format: 'json' })
+                window.open(url, '_blank')
+              }}
+              disabled={loading}
+            >
+              JSON
+            </button>
+          </span>
         </div>
       </header>
 

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -201,3 +201,18 @@ export function activityDetailLines(ev: {
   if (lines.length === 0 && ev.summary) lines.push(ev.summary)
   return lines
 }
+
+export function buildExportUrl(opts: {
+  from: string
+  to: string
+  userId: string
+  format: 'csv' | 'json'
+}): string {
+  const q = new URLSearchParams({
+    from: opts.from,
+    to: opts.to,
+    userId: opts.userId,
+    format: opts.format,
+  })
+  return `/api/activity/export?${q}`
+}

--- a/testing/functional/api/activityExport.test.ts
+++ b/testing/functional/api/activityExport.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { api, loginAs, SEED } from './helpers'
+
+describe('activity export', () => {
+  it('admin can export CSV', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const res = await api<string>(
+      '/api/activity/export?format=csv&from=2026-01-01&to=2026-12-31&userId=all',
+      { token, headers: { accept: 'text/csv' } },
+    )
+    expect(res.status).toBe(200)
+    expect(typeof res.data).toBe('string')
+    // CSV header
+    expect(res.data).toContain('id,user_id,user_name,event_type')
+  })
+
+  it('admin can export JSON', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const res = await api<{
+      from: string
+      to: string
+      exportedAt: string
+      events: unknown[]
+    }>('/api/activity/export?format=json&from=2026-01-01&to=2026-12-31&userId=all', {
+      token,
+    })
+    expect(res.status).toBe(200)
+    expect(res.data.from).toBe('2026-01-01')
+    expect(res.data.to).toBe('2026-12-31')
+    expect(Array.isArray(res.data.events)).toBe(true)
+  })
+
+  it('SDR cannot export (403)', async () => {
+    const { token } = await loginAs(SEED.sdr)
+    const res = await api(
+      '/api/activity/export?format=json&from=2026-01-01&to=2026-12-31&userId=all',
+      { token },
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects invalid format', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const res = await api(
+      '/api/activity/export?format=xml&from=2026-01-01&to=2026-12-31&userId=all',
+      { token },
+    )
+    expect(res.status).toBe(400)
+    expect(res.data).toHaveProperty('error')
+  })
+
+  it('rejects missing userId', async () => {
+    const { token } = await loginAs(SEED.founder)
+    const res = await api(
+      '/api/activity/export?format=json&from=2026-01-01&to=2026-12-31',
+      { token },
+    )
+    expect(res.status).toBe(400)
+  })
+})


### PR DESCRIPTION
## Description

Add activity export as CSV/JSON, addressing issue #49.

**Backend:**
- New `GET /api/activity/export?format=csv|json&from=&to=&userId=` endpoint
- Admin/founder only (403 for SDR role)
- CSV: proper escaping, header row, Content-Disposition attachment
- JSON: structured payload with metadata

**Frontend:**
- CSV and JSON export buttons on the SDR Activity page, near the Refresh button
- Reuses existing date range and user filters
- Downloads open in a new tab

**Docs:**
- `docs/API.md` updated with the new endpoint

**Tests:**
- Happy path: CSV and JSON export work
- Forbidden: SDR gets 403
- Validation: invalid format returns 400, missing userId returns 400

Closes #49