### PR TITLE
docs: clarify which settings are only editable via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,11 @@ Keep the **code** generic. Put company-specific values in env or the database:
 | ---- | ----- |
 | Postgres / JWT / email domain / S3 / CORS | Server `.env` (`DATABASE_URL`, `JWT_SECRET`, `ALLOWED_EMAIL_DOMAIN`, …) |
 | Brand name, logo, pipeline stages, contact statuses | DB `app_settings` — edit in **Settings** (founder/admin) or `PATCH /api/settings` |
+| Champion status → pipeline stage map (`championStatusToStage`) | **API / SQL only** today — `PATCH /api/settings` or [`sql/examples/convobrains-settings.sql`](sql/examples/convobrains-settings.sql) |
+| Discovery questions on the company form (`discoveryQuestions`) | **API / SQL only** today — same as above (not editable in the Settings UI yet) |
 | Optional first-boot brand | `BRAND_NAME`, `BRAND_TAGLINE`, `BRAND_LOGO_URL` in env (seeded once) |
 
-Example Convobrains status list: [`sql/examples/convobrains-settings.sql`](sql/examples/convobrains-settings.sql).
+Settings UI covers branding + stages + contact statuses. The champion sync map and discovery questions still go through the API (or the SQL example). See [`docs/API.md`](docs/API.md#settings-ui-vs-api-only) for a `PATCH` example.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,6 +12,45 @@ Unless noted, endpoints require `Authorization: Bearer <jwt>`.
 | `GET` | `/api/config` | Public instance config: email policy + branding, stages, contactStatuses, championStatusToStage, discoveryQuestions |
 | `PATCH` | `/api/settings` | Admin/founder: update branding + stages + contactStatuses (+ optional champion map / discoveryQuestions) |
 
+### Settings UI vs API-only
+
+The **Settings** page in the app can edit:
+
+- `brandName`, `brandTagline`, `logoUrl`
+- `stages` (pipeline)
+- `contactStatuses`
+
+These two are **not** on that page yet (easy to miss — they’re not broken, just API/SQL only):
+
+| Field | Purpose |
+| ----- | ------- |
+| `championStatusToStage` | When a champion’s contact status changes, optionally move the company to a pipeline stage |
+| `discoveryQuestions` | Extra questions shown on the company form (`id`, `section`, `prompt`, `input`) |
+
+Change them with `PATCH /api/settings` (founder/admin JWT) or seed via [`sql/examples/convobrains-settings.sql`](../sql/examples/convobrains-settings.sql).
+
+```bash
+curl -s -X PATCH http://localhost:4000/api/settings \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "championStatusToStage": {
+      "Connected - Booked a Discovery Call": "Discovery Call Done",
+      "Interested": "Follow-up"
+    },
+    "discoveryQuestions": [
+      {
+        "id": "budget",
+        "section": "Discovery",
+        "prompt": "Rough annual budget?",
+        "input": "text"
+      }
+    ]
+  }'
+```
+
+`GET /api/config` returns the current map and questions (no auth) so the SPA can use them.
+
 ## Auth
 
 | Method | Path | Description |

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -72,6 +72,23 @@ export function SettingsPage({ config, onSaved }: SettingsPageProps) {
           Branding and pipeline lists are stored in the database so Zero Cost CRM stays
           generic. Email domain and database URL stay in server env.
         </p>
+        <p className="mt-2 text-xs text-stone-500">
+          Champion status → stage mapping and discovery questions aren&apos;t on this
+          screen yet — update them with{' '}
+          <code className="rounded bg-stone-100 px-1 py-0.5 text-[11px]">
+            PATCH /api/settings
+          </code>{' '}
+          or see{' '}
+          <a
+            className="underline decoration-stone-300 underline-offset-2 hover:text-stone-700"
+            href="https://github.com/ConvoBrains/zero-cost-crm/blob/main/docs/API.md#settings-ui-vs-api-only"
+            target="_blank"
+            rel="noreferrer"
+          >
+            docs/API.md
+          </a>
+          .
+        </p>
       </div>
 
       <form


### PR DESCRIPTION
## Summary
Was easy to think champion status mapping and discovery questions were missing from Settings — they're just not on that screen yet.

- README table calls out the Settings UI vs API-only split
- `docs/API.md` has a short section + example `PATCH /api/settings`
- tiny note on the Settings page pointing people at the docs

No behavior change to how settings save.

Closes #46

## How I checked
- read through SettingsPage + PATCH handler so the note matches reality
- docs-only + UI copy