### PR TITLE
fix: show Last contacted column and filter on Contacts

### DIFF
--- a/src/components/Contacts.tsx
+++ b/src/components/Contacts.tsx
@@ -20,7 +20,8 @@ interface ContactsProps {
   stages?: string[];
 }
 
-function formatAddedDate(iso: string): string {
+function formatIsoDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
   return iso.slice(0, 10) || '—';
 }
 
@@ -70,7 +71,12 @@ function ContactRow({
         {contact.nextFollowUp ? (
           <span className="text-xs text-amber-700">Follow-up {contact.nextFollowUp}</span>
         ) : null}
-        <span className="text-xs text-stone-400">Added {formatAddedDate(contact.createdAt)}</span>
+        {contact.lastContacted ? (
+          <span className="text-xs text-stone-500">
+            Last {formatIsoDate(contact.lastContacted)}
+          </span>
+        ) : null}
+        <span className="text-xs text-stone-400">Added {formatIsoDate(contact.createdAt)}</span>
       </div>
     </button>
   );
@@ -181,6 +187,9 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
         case 'nextFollowUp':
           cmp = (a.nextFollowUp ?? '9999-12-31').localeCompare(b.nextFollowUp ?? '9999-12-31');
           break;
+        case 'lastContacted':
+          cmp = (a.lastContacted ?? '0000-01-01').localeCompare(b.lastContacted ?? '0000-01-01');
+          break;
         case 'createdAt':
           cmp = a.createdAt.localeCompare(b.createdAt);
           break;
@@ -205,13 +214,16 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
       setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
     } else {
       setSortKey(key);
-      setSortDir(key === 'createdAt' ? 'desc' : 'asc');
+      setSortDir(key === 'createdAt' || key === 'lastContacted' ? 'desc' : 'asc');
     }
   };
 
   const queueLabel = CONTACT_QUEUE_OPTIONS.find((o) => o.value === filters.queue)?.label ?? 'All';
   const dateLabel =
     CONTACT_DATE_RANGE_OPTIONS.find((o) => o.value === filters.dateRange)?.label ?? 'All Time';
+  const lastContactedLabel =
+    CONTACT_DATE_RANGE_OPTIONS.find((o) => o.value === filters.lastContactedRange)?.label ??
+    'All Time';
   const companyLabel = companyOptions.find((o) => o.value === filters.companyId)?.label ?? null;
 
   return (
@@ -247,6 +259,16 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
           options={CONTACT_DATE_RANGE_OPTIONS}
           active={filters.dateRange !== 'all'}
           onChange={(v) => patchFilters({ dateRange: v as ContactFilters['dateRange'] })}
+        />
+        <FilterDropdown
+          data-testid="contact-last-contacted-range"
+          label="Last contacted"
+          value={filters.lastContactedRange}
+          options={CONTACT_DATE_RANGE_OPTIONS}
+          active={filters.lastContactedRange !== 'all'}
+          onChange={(v) =>
+            patchFilters({ lastContactedRange: v as ContactFilters['lastContactedRange'] })
+          }
         />
       </div>
 
@@ -347,6 +369,12 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
             <FilterChip
               label={`Added: ${dateLabel}`}
               onClear={() => patchFilters({ dateRange: 'all' })}
+            />
+          ) : null}
+          {filters.lastContactedRange !== 'all' ? (
+            <FilterChip
+              label={`Last contacted: ${lastContactedLabel}`}
+              onClear={() => patchFilters({ lastContactedRange: 'all' })}
             />
           ) : null}
           <button
@@ -497,7 +525,7 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
 
       <div className="hidden overflow-hidden rounded-none border border-[var(--color-line)] bg-[var(--color-panel)] md:block">
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[960px] text-left text-sm">
+          <table className="w-full min-w-[1080px] text-left text-sm">
             <thead>
               <tr className="border-b border-[var(--color-line)] bg-stone-50/80 text-[11px] tracking-wide text-stone-500">
                 <SortHeader
@@ -533,6 +561,13 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
                 <SortHeader
                   label="Follow-up"
                   sortKey="nextFollowUp"
+                  activeKey={sortKey}
+                  direction={sortDir}
+                  onSort={onSort}
+                />
+                <SortHeader
+                  label="Last contacted"
+                  sortKey="lastContacted"
                   activeKey={sortKey}
                   direction={sortDir}
                   onSort={onSort}
@@ -578,13 +613,14 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
                     <td className="px-4 py-3 text-stone-600">{company?.stage ?? '—'}</td>
                     <td className="px-4 py-3 text-stone-600">{t.phone || '—'}</td>
                     <td className="px-4 py-3 text-stone-500">{t.nextFollowUp || '—'}</td>
-                    <td className="px-4 py-3 text-stone-500">{formatAddedDate(t.createdAt)}</td>
+                    <td className="px-4 py-3 text-stone-500">{formatIsoDate(t.lastContacted)}</td>
+                    <td className="px-4 py-3 text-stone-500">{formatIsoDate(t.createdAt)}</td>
                   </tr>
                 );
               })}
               {sorted.length === 0 ? (
                 <tr>
-                  <td colSpan={8} className="px-4 py-10 text-center text-sm text-stone-400">
+                  <td colSpan={9} className="px-4 py-10 text-center text-sm text-stone-400">
                     No contacts match these filters.
                   </td>
                 </tr>

--- a/src/lib/views.ts
+++ b/src/lib/views.ts
@@ -101,6 +101,7 @@ export const DEFAULT_CONTACT_FILTERS: ContactFilters = {
   stages: [],
   championOnly: false,
   dateRange: 'all',
+  lastContactedRange: 'all',
 };
 
 export const CONTACT_QUEUE_OPTIONS: { value: ContactFilters['queue']; label: string }[] = [
@@ -187,7 +188,8 @@ function matchesQueue(contact: Contact, queue: ContactFilters['queue']): boolean
 
 /**
  * Composable Contacts-page filter (search + queue + status + company + stage +
- * champion + createdAt date range). Companies are required for search/stage joins.
+ * champion + createdAt + lastContacted date ranges). Companies are required for
+ * search/stage joins.
  */
 export function applyContactFilters(
   contacts: Contact[],
@@ -197,6 +199,7 @@ export function applyContactFilters(
   const companyById = new Map(companies.map((c) => [c.id, c]));
   const search = filters.search.trim().toLowerCase();
   const dateStart = dateRangeStartIso(filters.dateRange);
+  const lastContactedStart = dateRangeStartIso(filters.lastContactedRange);
 
   return contacts.filter((contact) => {
     if (!matchesQueue(contact, filters.queue)) return false;
@@ -210,6 +213,10 @@ export function applyContactFilters(
     if (filters.championOnly && !contact.champion) return false;
 
     if (dateStart && createdAtDate(contact.createdAt) < dateStart) return false;
+
+    if (lastContactedStart) {
+      if (!contact.lastContacted || contact.lastContacted < lastContactedStart) return false;
+    }
 
     const company = contact.companyId ? companyById.get(contact.companyId) : undefined;
 
@@ -314,7 +321,8 @@ export function contactFiltersAreActive(filters: ContactFilters): boolean {
     filters.companyId !== null ||
     filters.stages.length > 0 ||
     filters.championOnly ||
-    filters.dateRange !== 'all'
+    filters.dateRange !== 'all' ||
+    filters.lastContactedRange !== 'all'
   );
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,11 +93,17 @@ export type PipelineView =
 export type ContactQueue =
   'all' | 'to-call-today' | 'follow-up-today' | 'overdue' | 'didnt-pick-yesterday';
 
-/** Time window applied to `contact.createdAt` for the Contacts page filter bar + lead insights. */
+/** Time window applied to `contact.createdAt` / `contact.lastContacted` for Contacts filters. */
 export type ContactDateRange = 'all' | 'this-week' | 'this-month' | 'last-30-days';
 
 export type ContactSortKey =
-  'contactName' | 'companyName' | 'contactStatus' | 'stage' | 'nextFollowUp' | 'createdAt';
+  | 'contactName'
+  | 'companyName'
+  | 'contactStatus'
+  | 'stage'
+  | 'nextFollowUp'
+  | 'lastContacted'
+  | 'createdAt';
 
 export type SortDirection = 'asc' | 'desc';
 
@@ -109,7 +115,10 @@ export interface ContactFilters {
   companyId: string | null;
   stages: string[];
   championOnly: boolean;
+  /** Filters on `contact.createdAt` (Added date). */
   dateRange: ContactDateRange;
+  /** Filters on `contact.lastContacted`. Null dates are excluded when not `'all'`. */
+  lastContactedRange: ContactDateRange;
 }
 
 /** Time window applied to `company.createdAt` for Sales Pipeline board + progress insights. */

--- a/testing/e2e/contacts-filters.spec.ts
+++ b/testing/e2e/contacts-filters.spec.ts
@@ -72,4 +72,18 @@ test.describe('Contacts search + filters + insights (issue #41)', () => {
     await expect(page.getByTestId('contact-clear-filters')).toBeVisible();
     await expect(page.getByTestId('insight-total')).toBeVisible();
   });
+
+  test('last contacted filter and column are available', async ({ page }) => {
+    await loginAsFounder(page);
+    await navTo(page, 'Contacts');
+    await showAllContacts(page);
+
+    await expect(
+      page.locator('main table thead').getByRole('button', { name: /Last contacted/i })
+    ).toBeVisible();
+    await page.getByTestId('contact-last-contacted-range').click();
+    await page.getByRole('option', { name: 'This Week', exact: true }).click();
+    await expect(page.getByTestId('contact-clear-filters')).toBeVisible();
+    await expect(page.getByText('Last contacted: This Week')).toBeVisible();
+  });
 });

--- a/testing/unit/views.test.ts
+++ b/testing/unit/views.test.ts
@@ -62,6 +62,7 @@ const baseFilters = (): ContactFilters => ({
   stages: [],
   championOnly: false,
   dateRange: 'all',
+  lastContactedRange: 'all',
 });
 
 describe('filterCompanies', () => {
@@ -223,6 +224,36 @@ describe('applyContactFilters', () => {
       dateRange: 'last-30-days',
     });
     expect(result.map((c) => c.id)).toEqual(['r1']);
+  });
+
+  it('filters by lastContacted date range and excludes nulls', () => {
+    const today = todayIso();
+    const recent = contact({
+      id: 'lc1',
+      companyId: 'c1',
+      contactName: 'Recent Call',
+      contactStatus: "Didn't Pick",
+      lastContacted: today,
+    });
+    const old = contact({
+      id: 'lc2',
+      companyId: 'c1',
+      contactName: 'Old Call',
+      contactStatus: "Didn't Pick",
+      lastContacted: '2020-01-01',
+    });
+    const never = contact({
+      id: 'lc3',
+      companyId: 'c1',
+      contactName: 'Never Called',
+      contactStatus: 'Not Contacted',
+      lastContacted: null,
+    });
+    const result = applyContactFilters([recent, old, never], companies, {
+      ...baseFilters(),
+      lastContactedRange: 'last-30-days',
+    });
+    expect(result.map((c) => c.id)).toEqual(['lc1']);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a sortable **Last contacted** column (and mobile row hint) on the Contacts page
- Add a **Last contacted** date-range filter (same presets as Added); null dates are excluded when the filter is active
- Cover the new filter logic in unit tests and the Contacts filters e2e suite

## Test plan
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run test:api` (after `make test-up` + `test:api:prep`)
- [x] `npm run test:e2e -- testing/e2e/contacts-filters.spec.ts`
- [ ] Smoke Contacts on localhost against live Convobrains data (SSH tunnel was down during this change)


Made with [Cursor](https://cursor.com)