### PR TITLE
fix: accept bare domains in website/LinkedIn fields

### DIFF
--- a/src/components/CompanyForm.tsx
+++ b/src/components/CompanyForm.tsx
@@ -10,6 +10,7 @@ import {
   fetchCompanyHistory,
   type CompanyHistoryEvent,
 } from '../lib/activity';
+import { normalizeOptionalUrl } from '../lib/urls';
 
 interface CompanyFormProps {
   store: CrmStore;
@@ -131,9 +132,9 @@ export function CompanyForm({
       lastContacted: form.lastContacted || null,
       nextFollowUp: form.nextFollowUp || null,
       notes: form.notes,
-      sourceLink: form.sourceLink,
-      companyWebsite: form.companyWebsite,
-      linkedInCompany: form.linkedInCompany,
+      sourceLink: form.sourceLink.trim(),
+      companyWebsite: normalizeOptionalUrl(form.companyWebsite),
+      linkedInCompany: normalizeOptionalUrl(form.linkedInCompany),
       discoveryAnswers,
     };
 
@@ -287,31 +288,35 @@ export function CompanyForm({
 
         <Field label="Company Website">
           <input
-            type="url"
+            type="text"
+            inputMode="url"
+            autoComplete="url"
             className={inputClass}
             value={form.companyWebsite}
             onChange={(e) => set('companyWebsite', e.target.value)}
-            placeholder="https://"
+            placeholder="simplilearn.com or https://…"
           />
         </Field>
 
         <Field label="LinkedIn Company">
           <input
-            type="url"
+            type="text"
+            inputMode="url"
+            autoComplete="url"
             className={inputClass}
             value={form.linkedInCompany}
             onChange={(e) => set('linkedInCompany', e.target.value)}
-            placeholder="https://"
+            placeholder="linkedin.com/company/… or https://…"
           />
         </Field>
 
         <Field label="Source Link" className="sm:col-span-2">
           <input
-            type="url"
+            type="text"
             className={inputClass}
             value={form.sourceLink}
             onChange={(e) => set('sourceLink', e.target.value)}
-            placeholder="https://"
+            placeholder="URL or import tag"
           />
         </Field>
 

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from 'react';
 import type { Contact, Stage } from '../types';
 import { DEFAULT_CONTACT_STATUSES, DEFAULT_STAGES } from '../defaults';
 import type { CrmStore } from '../hooks/useCrmStore';
+import { normalizeOptionalUrl } from '../lib/urls';
 import { Field, inputClass, btnPrimary, btnGhost } from './ui';
 import { ConversationPanel } from './ConversationPanel';
 
@@ -65,7 +66,7 @@ export function ContactForm({
       role: form.role,
       phone: form.phone,
       email: form.email,
-      linkedInProfile: form.linkedInProfile,
+      linkedInProfile: normalizeOptionalUrl(form.linkedInProfile),
       contactStatus: form.contactStatus,
       champion: form.champion,
       lastContacted: form.lastContacted || null,
@@ -202,11 +203,13 @@ export function ContactForm({
 
         <Field label="LinkedIn Profile" className="sm:col-span-2">
           <input
-            type="url"
+            type="text"
+            inputMode="url"
+            autoComplete="url"
             className={inputClass}
             value={form.linkedInProfile}
             onChange={(e) => set('linkedInProfile', e.target.value)}
-            placeholder="https://"
+            placeholder="linkedin.com/in/… or https://…"
           />
         </Field>
 

--- a/src/lib/urls.ts
+++ b/src/lib/urls.ts
@@ -1,0 +1,28 @@
+/**
+ * Optional link helpers for company/contact forms.
+ * Native `type="url"` rejects bare domains like `simplilearn.com` and
+ * free-text source tags like `leads-import-jul27-2026`.
+ */
+
+/** True when the value already has a URI scheme (`https:`, `mailto:`, …). */
+export function hasUriScheme(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value.trim());
+}
+
+/**
+ * Normalize an optional website / LinkedIn / profile value for storage.
+ * - empty → ''
+ * - already has a scheme → trimmed as-is
+ * - bare domain / host+path (e.g. `simplilearn.com`) → `https://…`
+ * - other free text → trimmed as-is (caller may still store it)
+ */
+export function normalizeOptionalUrl(raw: string): string {
+  const value = raw.trim();
+  if (!value) return '';
+  if (hasUriScheme(value)) return value;
+  // host.tld or host.tld/path — common paste from Sheets / LinkedIn without scheme
+  if (/^[\w.-]+\.[a-z]{2,}([/:?#].*)?$/i.test(value)) {
+    return `https://${value}`;
+  }
+  return value;
+}

--- a/testing/unit/urls.test.ts
+++ b/testing/unit/urls.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { hasUriScheme, normalizeOptionalUrl } from '../../src/lib/urls';
+
+describe('hasUriScheme', () => {
+  it('detects common schemes', () => {
+    expect(hasUriScheme('https://simplilearn.com')).toBe(true);
+    expect(hasUriScheme('http://example.com')).toBe(true);
+    expect(hasUriScheme('mailto:a@b.com')).toBe(true);
+  });
+
+  it('rejects bare domains', () => {
+    expect(hasUriScheme('simplilearn.com')).toBe(false);
+    expect(hasUriScheme('')).toBe(false);
+  });
+});
+
+describe('normalizeOptionalUrl', () => {
+  it('returns empty for blank input', () => {
+    expect(normalizeOptionalUrl('')).toBe('');
+    expect(normalizeOptionalUrl('   ')).toBe('');
+  });
+
+  it('keeps values that already have a scheme', () => {
+    expect(normalizeOptionalUrl('https://simplilearn.com')).toBe('https://simplilearn.com');
+    expect(normalizeOptionalUrl('  http://example.com/path  ')).toBe('http://example.com/path');
+  });
+
+  it('prefixes https:// for bare domains (the save-blocker case)', () => {
+    expect(normalizeOptionalUrl('simplilearn.com')).toBe('https://simplilearn.com');
+    expect(normalizeOptionalUrl('www.example.co.uk/about')).toBe('https://www.example.co.uk/about');
+    expect(normalizeOptionalUrl('linkedin.com/company/acme')).toBe(
+      'https://linkedin.com/company/acme'
+    );
+  });
+
+  it('leaves free-text source tags unchanged', () => {
+    expect(normalizeOptionalUrl('leads-import-jul27-2026')).toBe('leads-import-jul27-2026');
+  });
+});


### PR DESCRIPTION
## Summary
- Browser `type=\"url\"` validation was blocking company saves when Website was a bare domain (e.g. `simplilearn.com`) — tooltip: \"Please enter a URL.\"
- Switch Company Website / LinkedIn / Source Link (and contact LinkedIn) to text inputs
- Normalize bare domains to `https://…` on submit; leave free-text source tags (e.g. `leads-import-jul27-2026`) unchanged

## Test plan
- [x] `npm run lint` / `test` / `build` / `test:api`


Made with [Cursor](https://cursor.com)