### PR TITLE
docs: adding OpenAPI 3 specification for the REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 Most early-stage B2B teams hire their first SDR and manage them on Google Sheets,
 scattered call recordings, and founder intuition. We built the system we wished existed.
 
-[Run locally](#run-it-in-3-steps) · [Good first issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · [Fun issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3Afun) · [Architecture](docs/ARCHITECTURE.md) · [API](docs/API.md) · [Contributing](CONTRIBUTING.md) · [Discussions](https://github.com/ConvoBrains/zero-cost-crm/discussions) · [Security](SECURITY.md) · **[Book a demo](https://www.convobrains.com/contact)**
+[Run locally](#run-it-in-3-steps) · [Good first issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · [Fun issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3Afun) · [Architecture](docs/ARCHITECTURE.md) · [API](docs/API.md) · [OpenAPI](openapi.yaml) · [Contributing](CONTRIBUTING.md) · [Discussions](https://github.com/ConvoBrains/zero-cost-crm/discussions) · [Security](SECURITY.md) · **[Book a demo](https://www.convobrains.com/contact)**
 
 > **New here?** `make setup && make dev` → open [localhost:5173](http://localhost:5173) → pick an unassigned [good first issue](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee) → comment *I'd like to take this*. We review fast and mentor first-timers. Rewards: see [#23](https://github.com/ConvoBrains/zero-cost-crm/issues/23).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,6 +4,15 @@ Base URL: same origin as the app, or `http://localhost:4000` in development.
 
 Unless noted, endpoints require `Authorization: Bearer <jwt>`.
 
+## OpenAPI Specification
+
+A complete machine-readable OpenAPI 3.1 contract is available in [`openapi.yaml`](../openapi.yaml).
+
+### How to view the spec
+- **Redocly CLI**: Run `npx @redocly/cli build-docs openapi.yaml` to generate an interactive HTML documentation bundle (`redoc-static.html`).
+- **Swagger Editor**: Copy [`openapi.yaml`](../openapi.yaml) into [editor.swagger.io](https://editor.swagger.io).
+- **VS Code Extension**: Use the *OpenAPI (Swagger) Editor* extension for live preview.
+
 ## Public
 
 | Method  | Path            | Description                                                                                                         |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,14 +3,13 @@ openapi: 3.1.0
 info:
   title: Zero Cost CRM API
   version: 1.1.0
-
+#___________________________Components________________________
 components:
   securitySchemes:
     bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
-
   schemas:
     ErrorResponse:
       type: object
@@ -19,7 +18,6 @@ components:
       properties:
         error:
           type: string
-
     DiscoveryQuestion:
       type: object
       required:
@@ -40,7 +38,6 @@ components:
             - text
             - textarea
             - number
-
     ConfigResponse:
       type: object
       required:
@@ -55,26 +52,20 @@ components:
         - allowedEmailDomains
         - allowAnyEmailDomain
       properties:
-
         brandName:
           type: string
-
         brandTagline:
           type: string
-
         logoUrl:
           type: string
-
         stages:
           type: array
           items:
             type: string
-
         contactStatuses:
           type: array
           items:
             type: string
-
         championStatusToStage:
           type: object
           additionalProperties:
@@ -162,13 +153,10 @@ components:
           type:
             - string
             - "null"
-
-
-
-
+#_____________________ Security _____________________
 security:
   - bearerAuth: []
-
+#_____________________ Paths ______________________
 paths:
   /api/health:
     get:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1254,3 +1254,36 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "409":
           $ref: "#/components/responses/DuplicateRequest"
+  /api/conversations:
+    get:
+      parameters:
+        - name: contactId
+          in: query
+          required: false
+          description: Contact identifier.
+          schema:
+            type: string
+            format: uuid
+        - name: companyId
+          in: query
+          required: false
+          description: Company identifier.
+          schema:
+            type: string
+            format: uuid
+      summary: List conversations (by contactId / companyId).
+      responses:
+        "200":
+          description: Conversation retrieval successful.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Conversation"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+
+
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1283,7 +1283,41 @@ paths:
                   $ref: "#/components/schemas/Conversation"
         "401":
           $ref: "#/components/responses/Unauthorized"
-
-
-
+  /api/conversations/{id}/play:
+    get:
+      summary: Presigned play URL.
+      parameters:
+        - $ref: "#/components/parameters/id"
+      responses:
+        "200":
+          description: Presigned URL successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - playUrl
+                properties:
+                  playUrl:
+                    type: string
+                    format: uri
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/conversations/{id}:
+    delete:
+      summary: Delete a conversation.
+      description: Requires an authorized admin user.
+      parameters:
+        - $ref: "#/components/parameters/id"
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -241,7 +241,20 @@ components:
 
 #_____________________ Security _____________________
 
-security:
+    HeartBeatResponse:
+      type: object
+      required:
+        - ok
+        - lastActiveAt
+      properties:
+        ok:
+          type: boolean
+          example: true
+        lastActiveAt:
+          type: string
+          format: date-time
+
+security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
 #_____________________ Paths ______________________
 paths:
@@ -358,6 +371,18 @@ paths:
       responses:
         "204":
           description: Successful logout.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /api/auth/heartbeat:
+    post:
+      summary: Touch active session.
+      responses:
+        "200":
+          description: Session is valid
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HeartBeatResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -119,11 +119,11 @@ components:
           type: string
         estimatedCallVolume:
           type:
-            - number
+            - integer
             - "null"
         employeeCount:
           type:
-            - number
+            - integer
             - "null"
         intent:
           type: string
@@ -224,8 +224,6 @@ components:
         createdAt:
           type: string
           format: date-time
-
-
     DiscoveryQuestion:
       type: object
       required:
@@ -451,6 +449,36 @@ components:
         createdAt:
           type: string
           format: date-time
+    Metrics:
+      type: object
+      required:
+        - totalCompanies
+        - totalContacts
+        - newLeads
+        - followUpsDueToday
+        - demoScheduled
+        - activeOpportunities
+        - closedWon
+        - closedLost
+      properties:
+        totalCompanies:
+          type: integer
+        totalContacts:
+          type: integer
+        newLeads:
+          type: integer
+        followUpsDueToday:
+          type: integer
+        demoScheduled:
+          type: integer
+        activeOpportunities:
+          type: integer
+        closedWon:
+          type: integer
+        closedLost:
+          type: integer
+
+
 
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
@@ -701,6 +729,18 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/Contact"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /api/metrics:
+    get:
+      summary: Retrieves the metrics.
+      responses:
+        "200":
+          description: Metrics successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Metrics"
         "401":
           $ref: "#/components/responses/Unauthorized"
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,11 @@ openapi: 3.1.0
 info:
   title: Zero Cost CRM API
   version: 1.1.0
-#___________________________Components________________________
+
+servers:
+  - url: http://localhost:4000
+    description: Local development server.
+
 components:
   responses:
     BadRequest:
@@ -36,7 +40,6 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
-
   securitySchemes:
     bearerAuth:
       type: http
@@ -87,7 +90,6 @@ components:
             - text
             - textarea
             - number
-
     ErrorResponse:
       type: object
       required:
@@ -95,7 +97,6 @@ components:
       properties:
         error:
           type: string
-
     ConfigResponse:
       type: object
       required:
@@ -144,7 +145,6 @@ components:
             type: string
         allowAnyEmailDomain:
           type: boolean
-
     SettingsPatch:
       type: object
       properties:
@@ -232,7 +232,6 @@ components:
           description: Minimum length; 8 characters.
         role:
           $ref: "#/components/schemas/UserRoles"
-
     LoginRequest:
       type: object
       required:
@@ -256,6 +255,7 @@ components:
       properties:
         token:
           type: string
+          format: jwt
           description: JWT bearer token
         user:
           $ref: "#/components/schemas/User"
@@ -294,15 +294,10 @@ components:
           type: string
           format: date-time
 
-
-
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
-#_____________________ Paths ______________________
+
 paths:
-  #=========================
-  # PUBLIC ENDPOINTS
-  #=========================
   /api/health:
     get:
       security: []
@@ -365,9 +360,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-  #=========================
-  # AUTH ENDPOINTS
-  #=========================
+
   /api/auth/login:
     post:
       security: []
@@ -444,34 +437,10 @@ paths:
                     $ref: "#/components/schemas/User"
         "401":
           $ref: "#/components/responses/Unauthorized"
-  #=========================
-  # Users ENDPOINTS
-  #=========================
-  /api/users/roles:
-    get:
-      summary: Allowed user roles.
-      description: Requires an authenticated admin user.
-      responses:
-        "200":
-          description: Returns the list of allowed roles.
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - roles
-                properties:
-                  roles:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/UserRoles"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/Forbidden"
+
   /api/users:
     get:
-      summary: Retrives all users.
+      summary: Retrieves all users.
       description: Requires an authenticated admin user.
       responses:
         "200":
@@ -528,3 +497,26 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/CreateUserRequest"
+  /api/users/roles:
+    get:
+      summary: Allowed user roles.
+      description: Requires an authenticated admin user.
+      responses:
+        "200":
+          description: Returns the list of allowed roles.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - roles
+                properties:
+                  roles:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/UserRoles"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -802,6 +802,28 @@ components:
         stagingKey:
           type: string
 
+    Sdr:
+      type: object
+      required:
+        - id
+        - email
+        - name
+        - role
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+        role:
+          type: string
+          enum:
+            - sdr
+            - admin
+            - founder
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
 
@@ -1321,3 +1343,25 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
 
+  /api/activity/sdrs:
+    get:
+      summary: Returns the SDR roster.
+      description: Requires an authorized admin user.
+      responses:
+        "200":
+          description: SDR roster successfully retrieved.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - sdrs
+                properties:
+                  sdrs:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Sdr"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -48,6 +48,26 @@ components:
       scheme: bearer
       bearerFormat: JWT
   schemas:
+    CreateUserRequest:
+      type: object
+      required:
+        - name
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          description: User email address.
+          format: email
+        name:
+          type: string
+          description: Name of the user.
+        password:
+          type: string
+          format: password
+          description: Minimum length; 8 characters.
+        role:
+          $ref: "#/components/schemas/UserRoles"
     User:
       type: object
       required:
@@ -155,6 +175,60 @@ components:
         createdAt:
           type: string
           format: date
+    CreateCompanyRequest:
+      type: object
+      required:
+        - companyName
+      properties:
+        companyName:
+          type: string
+        stage:
+          type: string
+        industry:
+          type: string
+        location:
+          type: string
+        estimatedCallVolume:
+          type:
+            - integer
+            - "null"
+        employeeCount:
+          type:
+            - integer
+            - "null"
+        intent:
+          type: string
+        offeredPrice:
+          type:
+            - number
+            - "null"
+        primaryContactId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        lastContacted:
+          type:
+            - string
+            - "null"
+          format: date
+        nextFollowUp:
+          type:
+            - string
+            - "null"
+          format: date
+        notes:
+          type: string
+        sourceLink:
+          type: string
+        companyWebsite:
+          type: string
+        linkedInCompany:
+          type: string
+        discoveryAnswers:
+          type: object
+          additionalProperties:
+            type: string
     Contact:
       type: object
       required:
@@ -351,26 +425,6 @@ components:
           type:
             - string
             - "null"
-    CreateUserRequest:
-      type: object
-      required:
-        - name
-        - email
-        - password
-      properties:
-        email:
-          type: string
-          description: User email address.
-          format: email
-        name:
-          type: string
-          description: Name of the user.
-        password:
-          type: string
-          format: password
-          description: Minimum length; 8 characters.
-        role:
-          $ref: "#/components/schemas/UserRoles"
     LoginRequest:
       type: object
       required:
@@ -726,3 +780,22 @@ paths:
                 $ref: "#/components/schemas/Metrics"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /api/companies:
+    post:
+      summary: Create new company.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateCompanyRequest"
+      responses:
+        "201":
+          description: Company created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Company"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -970,6 +970,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
     delete:
       summary: Delete a company.
+      description: Requires an authorized admin user.
       responses:
         "204":
           $ref: "#/components/responses/NoContent"
@@ -1032,3 +1033,15 @@ paths:
           $ref: "#/components/responses/NotFound"
         "400":
           $ref: "#/components/responses/BadRequest"
+    delete:
+      summary: Delete a contact.
+      description: Requires an authorized admin user.
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1219,7 +1219,9 @@ components:
         targets:
           $ref: "#/components/schemas/ActivityTargets"
         session:
-          $ref: "#/components/schemas/SessionSummary"
+          oneOf:
+            - $ref: "#/components/schemas/SessionSummary"
+            - type: "null"
         metrics:
           $ref: "#/components/schemas/CallMetrics"
         productivity:
@@ -1679,7 +1681,7 @@ paths:
               $ref: "#/components/schemas/ConversationsPresignRequest"
       responses:
         "201":
-          description: Started conversaation upload.
+          description: Started conversation upload.
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -50,6 +50,7 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+
   securitySchemes:
     bearerAuth:
       type: http
@@ -289,7 +290,6 @@ components:
           type: object
           additionalProperties:
             type: string
-
     Contact:
       type: object
       required:
@@ -323,6 +323,7 @@ components:
           type: string
         email:
           type: string
+          format: email
         linkedInProfile:
           type: string
         contactStatus:
@@ -344,6 +345,43 @@ components:
         createdAt:
           type: string
           format: date
+    CreateContactRequest:
+      type: object
+      required:
+       - contactName
+      properties:
+        contactName:
+          type: string
+        companyId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        role:
+          type: string
+        phone:
+          type: string
+        email:
+          type: string
+          format: email
+        linkedInProfile:
+          type: string
+        contactStatus:
+          type: string
+        champion:
+          type: boolean
+        lastContacted:
+          type:
+            - string
+            - "null"
+          format: date
+        nextFollowUp:
+          type:
+            - string
+            - "null"
+          format: date
+        notes:
+          type: string
     DiscoveryQuestion:
       type: object
       required:
@@ -841,6 +879,7 @@ paths:
                 $ref: "#/components/schemas/Metrics"
         "401":
           $ref: "#/components/responses/Unauthorized"
+
   /api/companies:
     post:
       summary: Create new company.
@@ -902,3 +941,23 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/contacts:
+    post:
+      summary: Create a contact.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateContactRequest"
+      responses:
+        "201":
+          description: Contact created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Contact"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -96,11 +96,13 @@ components:
         allowAnyEmailDomain:
           type: boolean
 
-
+security:
+  - bearerAuth: []
 
 paths:
   /api/health:
     get:
+      security: []
       summary: Health check endpoint
       responses:
         "200":
@@ -119,6 +121,8 @@ paths:
 
   /api/config:
     get:
+      security: []
+
       summary: Public instance configuration
       responses:
         "200":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,6 +12,8 @@ servers:
 
 components:
   responses:
+    NoContent:
+      description: No Content.
     NotFound:
       description: Resource not found.
       content:
@@ -860,16 +862,16 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
   /api/companies/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Company Id
+        schema:
+          type: string
+          format: uuid
     patch:
-      summary: update company details.
-      parameters:
-        - name: id
-          in: path
-          required: true
-          description: Company Id
-          schema:
-            type: string
-            format: uuid
+      summary: Update a company.
       requestBody:
         required: true
         content:
@@ -889,3 +891,14 @@ paths:
           $ref: "#/components/responses/NotFound"
         "401":
           $ref: "#/components/responses/Unauthorized"
+    delete:
+      summary: Delete a company.
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11,6 +11,15 @@ servers:
     description: Local development server.
 
 components:
+  parameters:
+    id:
+      name: id
+      in: path
+      required: true
+      description: Resource identifier.
+      schema:
+        type: string
+        format: uuid
   responses:
     NoContent:
       description: No Content.
@@ -50,7 +59,6 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
-
   securitySchemes:
     bearerAuth:
       type: http
@@ -382,6 +390,42 @@ components:
           format: date
         notes:
           type: string
+    PatchContactRequest:
+      type: object
+      properties:
+        contactName:
+          type: string
+        companyId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        role:
+          type: string
+        phone:
+          type: string
+        email:
+          type: string
+          format: email
+        linkedInProfile:
+          type: string
+        contactStatus:
+          type: string
+        champion:
+          type: boolean
+        lastContacted:
+          type:
+            - string
+            - "null"
+          format: date
+        nextFollowUp:
+          type:
+            - string
+            - "null"
+          format: date
+        notes:
+          type: string
+
     DiscoveryQuestion:
       type: object
       required:
@@ -902,13 +946,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
   /api/companies/{id}:
     parameters:
-      - name: id
-        in: path
-        required: true
-        description: Company Id
-        schema:
-          type: string
-          format: uuid
+      - $ref: "#/components/parameters/id"
     patch:
       summary: Update a company.
       requestBody:
@@ -961,3 +999,36 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /api/contacts/{id}:
+    parameters:
+      - $ref: "#/components/parameters/id"
+    patch:
+      summary: Update a contact.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchContactRequest"
+      responses:
+        "200":
+          description: Contact updated successfully.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Contact"
+                  - type: object
+                    required:
+                      - movedCompanyStage
+                    properties:
+                      movedCompanyStage:
+                        type:
+                          - string
+                          - "null"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "400":
+          $ref: "#/components/responses/BadRequest"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,6 +28,40 @@ components:
       schema:
         type: string
         format: uuid
+
+    userIdQuery:
+      name: userId
+      in: query
+      required: true
+      description: SDR user ID (UUID) or 'all'.
+      schema:
+        type: string
+
+    fromQuery:
+      name: from
+      in: query
+      required: false
+      description: Start date (YYYY-MM-DD).
+      schema:
+        type: string
+        format: date
+
+    toQuery:
+      name: to
+      in: query
+      required: false
+      description: End date (YYYY-MM-DD).
+      schema:
+        type: string
+        format: date
+
+    qQuery:
+      name: q
+      in: query
+      required: false
+      description: Search term.
+      schema:
+        type: string
   responses:
     DuplicateRequest:
       description: Duplicate request.
@@ -982,6 +1016,30 @@ components:
         createdAt:
           type: string
           format: date-time
+    ActivityTimelineResponse:
+      type: object
+      required:
+        - date
+        - from
+        - to
+        - userId
+        - events
+      properties:
+        date:
+          type: string
+          format: date
+        from:
+          type: string
+          format: date
+        to:
+          type: string
+          format: date
+        userId:
+          type: string
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimelineEvent"
     EventType:
       type: string
       enum:
@@ -1640,6 +1698,28 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/LeadHistoryResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/activity/timeline:
+    get:
+      summary: Event timeline
+      description: Requires an authorized admin user.
+      parameters:
+        - $ref: "#/components/parameters/userIdQuery"
+        - $ref: "#/components/parameters/fromQuery"
+        - $ref: "#/components/parameters/toQuery"
+        - $ref: "#/components/parameters/qQuery"
+      responses:
+        "200":
+          description: Timeline events successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivityTimelineResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -242,7 +242,8 @@ components:
           type: string
           description: User email address.
           format: email
-          example: alice@example.com
+          examples:
+            - alice@example.com
         password:
           type: string
           format: password
@@ -267,7 +268,8 @@ components:
       properties:
         ok:
           type: boolean
-          example: true
+          examples:
+            - true
         lastActiveAt:
           type: string
           format: date-time
@@ -315,7 +317,8 @@ paths:
                   ok:
                     type: boolean
                     description: Indicates whether the API server is healthy.
-                    example: true
+                    examples:
+                      - true
   /api/config:
     get:
       security: []

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -71,7 +71,6 @@ components:
       scheme: bearer
       bearerFormat: JWT
   schemas:
-
     CreateUserRequest:
       type: object
       required:
@@ -844,17 +843,140 @@ components:
         - entityId
       properties:
         eventType:
-          type: string
-          enum:
-            - contact.opened
-            - company.opened
+          $ref: "#/components/schemas/EventType"
         entityId:
           type: string
           format: uuid
         name:
           type: string
-
-
+    CompanyHistoryEvent:
+      type: object
+      required:
+        - id
+        - userId
+        - userName
+        - eventType
+        - entityType
+        - summary
+        - payload
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        userName:
+          type: string
+        eventType:
+          type: string
+        entityType:
+          type: string
+        entityId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        contactName:
+          type:
+            - string
+            - "null"
+        summary:
+          type: string
+        payload:
+          type: object
+        createdAt:
+          type: string
+          format: date-time
+    LeadHistoryEvent:
+      type: object
+      required:
+        - id
+        - userId
+        - userName
+        - eventType
+        - summary
+        - payload
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        userName:
+          type: string
+        eventType:
+          type: string
+        summary:
+          type: string
+        payload:
+          type: object
+        createdAt:
+          type: string
+          format: date-time
+    TimelineEvent:
+      type: object
+      required:
+        - id
+        - userId
+        - userName
+        - eventType
+        - entityType
+        - summary
+        - payload
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        userName:
+          type: string
+        sessionId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        eventType:
+          type: string
+        entityType:
+          type: string
+        entityId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        summary:
+          type: string
+        payload:
+          type: object
+        createdAt:
+          type: string
+          format: date-time
+    EventType:
+      type: string
+      enum:
+        - contact.opened
+        - company.opened
+    CompanyHistoryResponse:
+      type: object
+      required:
+        - companyId
+        - companyName
+        - events
+      properties:
+        companyId:
+          type: string
+          format: uuid
+        companyName:
+          type: string
+        events:
+          $ref: "#/components/schemas/CompanyHistoryEvent"
 
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
@@ -1458,3 +1580,21 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /api/activity/company/{id}/history:
+    get:
+      summary: Company progress
+      parameters:
+        - $ref: "#/components/parameters/id"
+      responses:
+        "200":
+          description: Event history successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompanyHistoryResponse"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -824,6 +824,20 @@ components:
             - sdr
             - admin
             - founder
+    ActivityTargets:
+      type: object
+      required:
+        - calls
+        - followUps
+        - demos
+      properties:
+        calls:
+          type: integer
+        followUps:
+          type: integer
+        demos:
+          type: integer
+
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
 
@@ -1365,3 +1379,49 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/activity/targets:
+    get:
+      summary: Fetches daily targets.
+      description: Requires an authorized admin user.
+      responses:
+        "200":
+          description: Targets retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - targets
+                properties:
+                  targets:
+                    $ref: "#/components/schemas/ActivityTargets"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    patch:
+      summary: Update targets.
+      description: Requires an authorized admin user.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ActivityTargets"
+      responses:
+        "200":
+          description: Targets updated successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  targets:
+                    $ref: "#/components/schemas/ActivityTargets"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,6 +21,12 @@ components:
         type: string
         format: uuid
   responses:
+    DuplicateRequest:
+      description: Duplicate request.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
     NoContent:
       description: No Content.
     NotFound:
@@ -65,6 +71,7 @@ components:
       scheme: bearer
       bearerFormat: JWT
   schemas:
+
     CreateUserRequest:
       type: object
       required:
@@ -109,6 +116,29 @@ components:
         - founder
         - sdr
         - admin
+    UserResponse:
+      type: object
+      required:
+        - id
+        - email
+        - name
+        - role
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+        role:
+          $ref: "#/components/schemas/UserRoles"
+        createdAt:
+          type: string
+          format: date-time
+
     Company:
       type: object
       required:
@@ -298,6 +328,7 @@ components:
           type: object
           additionalProperties:
             type: string
+
     Contact:
       type: object
       required:
@@ -425,6 +456,7 @@ components:
           format: date
         notes:
           type: string
+
     DiscoveryQuestion:
       type: object
       required:
@@ -445,6 +477,7 @@ components:
             - text
             - textarea
             - number
+
     ErrorResponse:
       type: object
       required:
@@ -452,6 +485,7 @@ components:
       properties:
         error:
           type: string
+
     ConfigResponse:
       type: object
       required:
@@ -500,6 +534,7 @@ components:
             type: string
         allowAnyEmailDomain:
           type: boolean
+
     SettingsPatch:
       type: object
       properties:
@@ -567,6 +602,7 @@ components:
           type:
             - string
             - "null"
+
     LoginRequest:
       type: object
       required:
@@ -608,28 +644,7 @@ components:
         lastActiveAt:
           type: string
           format: date-time
-    UserResponse:
-      type: object
-      required:
-        - id
-        - email
-        - name
-        - role
-        - createdAt
-      properties:
-        id:
-          type: string
-          format: uuid
-        email:
-          type: string
-          format: email
-        name:
-          type: string
-        role:
-          $ref: "#/components/schemas/UserRoles"
-        createdAt:
-          type: string
-          format: date-time
+
     Metrics:
       type: object
       required:
@@ -658,8 +673,12 @@ components:
           type: integer
         closedLost:
           type: integer
+
     Prospect:
       type: object
+      required:
+        - company
+        - prospectName
       properties:
         company:
           type: string
@@ -706,6 +725,83 @@ components:
           type: integer
         contactsSkipped:
           type: integer
+
+    Conversation:
+      type: object
+      required:
+        - id
+        - companyId
+        - contactId
+        - companyName
+        - contactName
+        - calledBy
+        - calledByName
+        - stageAtCall
+        - calledAt
+        - s3Url
+        - notes
+      properties:
+        id:
+          type: string
+          format: uuid
+        companyId:
+          type: string
+          format: uuid
+        contactId:
+          type: string
+          format: uuid
+        companyName:
+          type: string
+        contactName:
+          type: string
+        calledBy:
+          type: string
+          format: uuid
+        calledByName:
+          type: string
+        stageAtCall:
+          type: string
+        calledAt:
+          type: string
+          format: date-time
+        s3Url:
+          type: string
+          format: uri
+        notes:
+          type: string
+    ConversationsPresignRequest:
+      type: object
+      required:
+        - contactId
+        - fileExt
+      properties:
+        contactId:
+          type: string
+          format: uuid
+        fileExt:
+          type: string
+        notes:
+          type:
+            - string
+            - "null"
+        stageAtCall:
+          type: string
+    ConversationsPresignResponse:
+      type: object
+      required:
+        - conversationId
+        - uploadUrl
+        - stagingKey
+      properties:
+        conversationId:
+          type: string
+          format: uuid
+        uploadUrl:
+          type: string
+          format: uri
+        stagingKey:
+          type: string
+
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
 
@@ -1091,6 +1187,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+
   /api/import/prospects:
     post:
       summary: Bulk import prospects.
@@ -1111,3 +1208,49 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
+
+  /api/conversations/presign:
+    post:
+      summary: Starts Upload.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConversationsPresignRequest"
+      responses:
+        "201":
+          description: Started conversaation upload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConversationsPresignResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/conversations/{id}/complete:
+    parameters:
+      - $ref: "#/components/parameters/id"
+    post:
+      summary: Finalize upload.
+      responses:
+        "200":
+          description: Upload successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Conversation"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/DuplicateRequest"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,19 +5,66 @@ info:
   version: 1.1.0
 #___________________________Components________________________
 components:
+  responses:
+    BadRequest:
+      description: Invalid request.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    TooManyRequests:
+      description: Too many requests. Please try again later.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    Unauthorized:
+      description: Missing, invalid, or expired bearer token.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    InvalidCredentials:
+      description: Invalid email or password.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    Forbidden:
+      description: Insufficient permissions.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
   securitySchemes:
     bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
   schemas:
-    ErrorResponse:
+    User:
       type: object
       required:
-        - error
+        - id
+        - email
+        - name
+        - role
       properties:
-        error:
+        id:
           type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+        role:
+          type: string
+          enum:
+            - founder
+            - sdr
+            - admin
     DiscoveryQuestion:
       type: object
       required:
@@ -38,6 +85,15 @@ components:
             - text
             - textarea
             - number
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+
     ConfigResponse:
       type: object
       required:
@@ -86,6 +142,7 @@ components:
             type: string
         allowAnyEmailDomain:
           type: boolean
+
     SettingsPatch:
       type: object
       properties:
@@ -153,11 +210,44 @@ components:
           type:
             - string
             - "null"
+
+    LoginRequest:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          description: User email address.
+          format: email
+          example: alice@example.com
+        password:
+          type: string
+          format: password
+          description: User password.
+    LoginResponse:
+      type: object
+      required:
+        - token
+        - user
+      properties:
+        token:
+          type: string
+          description: JWT bearer token
+        user:
+          $ref: "#/components/schemas/User"
+
+
 #_____________________ Security _____________________
+
 security:
   - bearerAuth: []
 #_____________________ Paths ______________________
 paths:
+  #=========================
+  # PUBLIC ENDPOINTS
+  #=========================
   /api/health:
     get:
       security: []
@@ -217,14 +307,36 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "401":
-          description: Missing, Invalid or Expired Bearer token.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
+          $ref: "#/components/responses/Unauthorized"
         "403":
-          description: Missing Admin privileges.
+          $ref: "#/components/responses/Forbidden"
+  #=========================
+  # AUTH ENDPOINTS
+  #=========================
+  /api/auth/login:
+    post:
+      security: []
+      summary: User login.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+      responses:
+        "200":
+          description: Successful user login.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LoginResponse"
+        "400":
+          description: Email address is not allowed.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/InvalidCredentials"
+        "429":
+          $ref: "#/components/responses/TooManyRequests"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1040,6 +1040,200 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TimelineEvent"
+    SessionSummary:
+      type: object
+      required:
+        - activeMs
+        - idleMs
+        - activeDuration
+        - idleDuration
+        - sessionCount
+        - endReasons
+      properties:
+        loginTime:
+          type:
+            - string
+            - "null"
+        logoutTime:
+          type:
+            - string
+            - "null"
+        activeMs:
+          type: integer
+        idleMs:
+          type: integer
+        activeDuration:
+          type: string
+        idleDuration:
+          type: string
+        sessionCount:
+          type: integer
+        firstLogin:
+          type:
+            - string
+            - "null"
+          format: date-time
+        lastActivity:
+          type:
+            - string
+            - "null"
+          format: date-time
+        endReasons:
+          type: array
+          items:
+            type: string
+    CallMetrics:
+      type: object
+      required:
+        - callsMade
+        - connected
+        - didntPick
+        - wrongPerson
+        - interested
+        - followUps
+        - demo
+        - notInterested
+        - converted
+      properties:
+        callsMade:
+          type: integer
+        connected:
+          type: integer
+        didntPick:
+          type: integer
+        wrongPerson:
+          type: integer
+        interested:
+          type: integer
+        followUps:
+          type: integer
+        demo:
+          type: integer
+        notInterested:
+          type: integer
+        converted:
+          type: integer
+    ProductivityStats:
+      type: object
+      required:
+        - contactsWorked
+        - companiesWorked
+        - callsPerHour
+        - avgMinutesPerLead
+      properties:
+        contactsWorked:
+          type: integer
+        companiesWorked:
+          type: integer
+        callsPerHour:
+          type: number
+        avgMinutesPerLead:
+          type: integer
+    ActivityAlert:
+      type: object
+      required:
+        - code
+        - severity
+        - message
+        - userId
+        - userName
+      properties:
+        code:
+          type: string
+        severity:
+          type: string
+          enum:
+            - warning
+            - critical
+        message:
+          type: string
+        userId:
+          type: string
+          format: uuid
+        userName:
+          type: string
+    AgentOverview:
+      type: object
+      required:
+        - userId
+        - name
+        - email
+        - role
+        - session
+        - metrics
+        - productivity
+        - targets
+        - progress
+        - alerts
+      properties:
+        userId:
+          type: string
+          format: uuid
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+        session:
+          $ref: "#/components/schemas/SessionSummary"
+        metrics:
+          $ref: "#/components/schemas/CallMetrics"
+        productivity:
+          $ref: "#/components/schemas/ProductivityStats"
+        targets:
+          $ref: "#/components/schemas/ActivityTargets"
+        progress:
+          $ref: "#/components/schemas/ActivityTargets"
+        alerts:
+          type: array
+          items:
+            $ref: "#/components/schemas/ActivityAlert"
+    ActivityOverviewResponse:
+      type: object
+      required:
+        - date
+        - from
+        - to
+        - userId
+        - targets
+        - session
+        - metrics
+        - productivity
+        - progress
+        - alerts
+        - agents
+      properties:
+        date:
+          type: string
+          format: date
+        from:
+          type: string
+          format: date
+        to:
+          type: string
+          format: date
+        userId:
+          type: string
+        targets:
+          $ref: "#/components/schemas/ActivityTargets"
+        session:
+          $ref: "#/components/schemas/SessionSummary"
+        metrics:
+          $ref: "#/components/schemas/CallMetrics"
+        productivity:
+          $ref: "#/components/schemas/ProductivityStats"
+        progress:
+          $ref: "#/components/schemas/ActivityTargets"
+        alerts:
+          type: array
+          items:
+            $ref: "#/components/schemas/ActivityAlert"
+        agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentOverview"
     EventType:
       type: string
       enum:
@@ -1704,6 +1898,30 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/activity/overview:
+    get:
+      summary: Manager overview dashboard
+      description: Requires an authorized admin user.
+      parameters:
+        - $ref: "#/components/parameters/userIdQuery"
+        - $ref: "#/components/parameters/fromQuery"
+        - $ref: "#/components/parameters/toQuery"
+        - $ref: "#/components/parameters/qQuery"
+      responses:
+        "200":
+          description: Activity overview metrics successfully retrieved.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActivityOverviewResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/activity/timeline:
     get:
       summary: Event timeline

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -60,11 +60,13 @@ components:
         name:
           type: string
         role:
-          type: string
-          enum:
-            - founder
-            - sdr
-            - admin
+          $ref: "#/components/schemas/UserRoles"
+    UserRoles:
+      type: string
+      enum:
+        - founder
+        - sdr
+        - admin
     DiscoveryQuestion:
       type: object
       required:
@@ -402,7 +404,29 @@ paths:
                     $ref: "#/components/schemas/User"
         "401":
           $ref: "#/components/responses/Unauthorized"
-
-
-
+  #=========================
+  # Users ENDPOINTS
+  #=========================
+  /api/users/roles:
+    get:
+      summary: Allowed user roles.
+      description: Requires an authenticated admin user.
+      responses:
+        "200":
+          description: Returns the list of allowed roles.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - roles
+                properties:
+                  roles:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/UserRoles"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -385,6 +385,24 @@ paths:
                 $ref: "#/components/schemas/HeartBeatResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /api/auth/me:
+    get:
+      summary: Current user
+      responses:
+        "200":
+          description: Contains current user object.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - user
+                properties:
+                  user:
+                    $ref: "#/components/schemas/User"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
 
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1269,6 +1269,7 @@ security: #as mentioned in API.md, all endpoints require auth
 paths:
   /api/health:
     get:
+      operationId: getHealth
       security: []
       summary: Health check endpoint
       responses:
@@ -1288,6 +1289,7 @@ paths:
                       - true
   /api/config:
     get:
+      operationId: getConfig
       security: []
       summary: Public instance configuration
       responses:
@@ -1305,6 +1307,7 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
   /api/settings:
     patch:
+      operationId: updateSettings
       summary: Update application settings.
       description: Requires an authenticated admin user.
       requestBody:
@@ -1333,6 +1336,7 @@ paths:
 
   /api/auth/login:
     post:
+      operationId: login
       security: []
       summary: User login.
       requestBody:
@@ -1360,6 +1364,7 @@ paths:
           $ref: "#/components/responses/TooManyRequests"
   /api/auth/logout:
     post:
+      operationId: logout
       summary: End session
       requestBody:
         content:
@@ -1380,6 +1385,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
   /api/auth/heartbeat:
     post:
+      operationId: heartbeat
       summary: Touch active session.
       responses:
         "200":
@@ -1392,6 +1398,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
   /api/auth/me:
     get:
+      operationId: getCurrentUser
       summary: Current user
       responses:
         "200":
@@ -1410,6 +1417,7 @@ paths:
 
   /api/users:
     get:
+      operationId: listUsers
       summary: Retrieves all users.
       description: Requires an authenticated admin user.
       responses:
@@ -1431,6 +1439,7 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
     post:
+      operationId: createUser
       summary: Creates a new user.
       description: Requires an authenticated admin user.
       requestBody:
@@ -1469,6 +1478,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
   /api/users/roles:
     get:
+      operationId: listUserRoles
       summary: Allowed user roles.
       description: Requires an authenticated admin user.
       responses:
@@ -1492,6 +1502,7 @@ paths:
 
   /api/bootstrap:
     get:
+      operationId: getBootstrapData
       summary: Retrieve companies and contacts.
       responses:
         "200":
@@ -1516,6 +1527,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
   /api/metrics:
     get:
+      operationId: getMetrics
       summary: Retrieves the metrics.
       responses:
         "200":
@@ -1529,6 +1541,7 @@ paths:
 
   /api/companies:
     post:
+      operationId: createCompany
       summary: Create new company.
       requestBody:
         required: true
@@ -1551,6 +1564,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/id"
     patch:
+      operationId: updateCompany
       summary: Update a company.
       requestBody:
         required: true
@@ -1572,6 +1586,7 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
     delete:
+      operationId: deleteCompany
       summary: Delete a company.
       description: Requires an authorized admin user.
       responses:
@@ -1585,6 +1600,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
   /api/contacts:
     post:
+      operationId: createContact
       summary: Create a contact.
       requestBody:
         required: true
@@ -1607,6 +1623,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/id"
     patch:
+      operationId: updateContact
       summary: Update a contact.
       requestBody:
         required: true
@@ -1637,6 +1654,7 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequest"
     delete:
+      operationId: deleteContact
       summary: Delete a contact.
       description: Requires an authorized admin user.
       responses:
@@ -1651,6 +1669,7 @@ paths:
 
   /api/import/prospects:
     post:
+      operationId: importProspects
       summary: Bulk import prospects.
       requestBody:
         required: true
@@ -1672,6 +1691,7 @@ paths:
 
   /api/conversations/presign:
     post:
+      operationId: presignConversationUpload
       summary: Starts Upload.
       requestBody:
         required: true
@@ -1697,6 +1717,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/id"
     post:
+      operationId: completeConversationUpload
       summary: Finalize upload.
       responses:
         "200":
@@ -1717,6 +1738,7 @@ paths:
           $ref: "#/components/responses/DuplicateRequest"
   /api/conversations:
     get:
+      operationId: listConversations
       parameters:
         - name: contactId
           in: query
@@ -1746,6 +1768,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
   /api/conversations/{id}/play:
     get:
+      operationId: getConversationPlayUrl
       summary: Presigned play URL.
       parameters:
         - $ref: "#/components/parameters/id"
@@ -1768,6 +1791,7 @@ paths:
           $ref: "#/components/responses/NotFound"
   /api/conversations/{id}:
     delete:
+      operationId: deleteConversation
       summary: Delete a conversation.
       description: Requires an authorized admin user.
       parameters:
@@ -1784,6 +1808,7 @@ paths:
 
   /api/activity/sdrs:
     get:
+      operationId: listSdrs
       summary: Returns the SDR roster.
       description: Requires an authorized admin user.
       responses:
@@ -1806,6 +1831,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
   /api/activity/targets:
     get:
+      operationId: getActivityTargets
       summary: Fetches daily targets.
       description: Requires an authorized admin user.
       responses:
@@ -1825,6 +1851,7 @@ paths:
         "403":
           $ref: "#/components/responses/Forbidden"
     patch:
+      operationId: updateActivityTargets
       summary: Update targets.
       description: Requires an authorized admin user.
       requestBody:
@@ -1851,6 +1878,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
   /api/activity/events:
     post:
+      operationId: logActivityEvent
       summary: Client-side activity event
       requestBody:
         required: true
@@ -1867,6 +1895,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
   /api/activity/company/{id}/history:
     get:
+      operationId: getCompanyActivityHistory
       summary: Company progress
       parameters:
         - $ref: "#/components/parameters/id"
@@ -1883,6 +1912,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
   /api/activity/lead/{entityType}/{id}:
     get:
+      operationId: getLeadActivityHistory
       parameters:
         - $ref: "#/components/parameters/id"
         - $ref: "#/components/parameters/entityType"
@@ -1902,6 +1932,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
   /api/activity/overview:
     get:
+      operationId: getActivityOverview
       summary: Manager overview dashboard
       description: Requires an authorized admin user.
       parameters:
@@ -1926,6 +1957,7 @@ paths:
           $ref: "#/components/responses/NotFound"
   /api/activity/timeline:
     get:
+      operationId: getActivityTimeline
       summary: Event timeline
       description: Requires an authorized admin user.
       parameters:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -104,17 +104,6 @@ components:
           type: string
         industry:
           type: string
-          enum:
-            - BFSI
-            - Healthcare
-            - Retail
-            - EdTech
-            - Telecom
-            - SaaS
-            - Logistics
-            - Research / Biotech
-            - Other
-            - ""
         location:
           type: string
         estimatedCallVolume:
@@ -127,11 +116,7 @@ components:
             - "null"
         intent:
           type: string
-          enum:
-            - ""
-            - Hot
-            - Cold
-            - Warm
+
         offeredPrice:
           type:
             - number
@@ -149,12 +134,12 @@ components:
           type:
             - string
             - "null"
-          format: date-time
+          format: date
         nextFollowUp:
           type:
             - string
             - "null"
-          format: date-time
+          format: date
         notes:
           type: string
         sourceLink:
@@ -169,7 +154,7 @@ components:
             type: string
         createdAt:
           type: string
-          format: date-time
+          format: date
     Contact:
       type: object
       required:
@@ -213,17 +198,17 @@ components:
           type:
             - string
             - "null"
-          format: date-time
+          format: date
         nextFollowUp:
           type:
             - string
             - "null"
-          format: date-time
+          format: date
         notes:
           type: string
         createdAt:
           type: string
-          format: date-time
+          format: date
     DiscoveryQuestion:
       type: object
       required:
@@ -478,8 +463,6 @@ components:
         closedLost:
           type: integer
 
-
-
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
 
@@ -650,6 +633,12 @@ paths:
     post:
       summary: Creates a new user.
       description: Requires an authenticated admin user.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateUserRequest"
       responses:
         "201":
           description: Returns the new user.
@@ -678,12 +667,6 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/CreateUserRequest"
   /api/users/roles:
     get:
       summary: Allowed user roles.
@@ -743,6 +726,3 @@ paths:
                 $ref: "#/components/schemas/Metrics"
         "401":
           $ref: "#/components/responses/Unauthorized"
-
-
-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,6 +12,12 @@ servers:
 
 components:
   responses:
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
     BadRequest:
       description: Invalid request.
       content:
@@ -229,6 +235,59 @@ components:
           type: object
           additionalProperties:
             type: string
+    PatchCompanyRequest:
+      type: object
+      properties:
+        companyName:
+          type: string
+        stage:
+          type: string
+        industry:
+          type: string
+        location:
+          type: string
+        estimatedCallVolume:
+          type:
+            - integer
+            - "null"
+        employeeCount:
+          type:
+            - integer
+            - "null"
+        intent:
+          type: string
+        offeredPrice:
+          type:
+            - number
+            - "null"
+        primaryContactId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        lastContacted:
+          type:
+            - string
+            - "null"
+          format: date
+        nextFollowUp:
+          type:
+            - string
+            - "null"
+          format: date
+        notes:
+          type: string
+        sourceLink:
+          type: string
+        companyWebsite:
+          type: string
+        linkedInCompany:
+          type: string
+        discoveryAnswers:
+          type: object
+          additionalProperties:
+            type: string
+
     Contact:
       type: object
       required:
@@ -798,4 +857,35 @@ paths:
                 $ref: "#/components/schemas/Company"
         "400":
           $ref: "#/components/responses/BadRequest"
-
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /api/companies/{id}:
+    patch:
+      summary: update company details.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Company Id
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PatchCompanyRequest"
+      responses:
+        "200":
+          description: Company updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Company"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "401":
+          $ref: "#/components/responses/Unauthorized"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -976,7 +976,9 @@ components:
         companyName:
           type: string
         events:
-          $ref: "#/components/schemas/CompanyHistoryEvent"
+          type: array
+          items:
+            $ref: "#/components/schemas/CompanyHistoryEvent"
 
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
@@ -1591,10 +1593,8 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CompanyHistoryResponse"
+                  $ref: "#/components/schemas/CompanyHistoryResponse"
         "404":
           $ref: "#/components/responses/NotFound"
         "401":
           $ref: "#/components/responses/Unauthorized"
-
-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -340,3 +340,26 @@ paths:
           $ref: "#/components/responses/InvalidCredentials"
         "429":
           $ref: "#/components/responses/TooManyRequests"
+  /api/auth/logout:
+    post:
+      summary: End session
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  enum:
+                    - idle
+                    - expired
+                    - manual
+      responses:
+        "204":
+          description: Successful logout.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -837,6 +837,24 @@ components:
           type: integer
         demos:
           type: integer
+    ActivityEvent:
+      type: object
+      required:
+        - eventType
+        - entityId
+      properties:
+        eventType:
+          type: string
+          enum:
+            - contact.opened
+            - company.opened
+        entityId:
+          type: string
+          format: uuid
+        name:
+          type: string
+
+
 
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
@@ -1424,4 +1442,19 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-
+  /api/activity/events:
+    post:
+      summary: Client-side activity event
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ActivityEvent"
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,6 +3,8 @@ openapi: 3.1.0
 info:
   title: Zero Cost CRM API
   version: 1.1.0
+  license:
+    name: MIT
 
 servers:
   - url: http://localhost:4000
@@ -70,6 +72,160 @@ components:
         - founder
         - sdr
         - admin
+    Company:
+      type: object
+      required:
+        - id
+        - companyName
+        - stage
+        - industry
+        - location
+        - estimatedCallVolume
+        - employeeCount
+        - intent
+        - offeredPrice
+        - primaryContactId
+        - assignedTo
+        - lastContacted
+        - nextFollowUp
+        - notes
+        - sourceLink
+        - companyWebsite
+        - linkedInCompany
+        - discoveryAnswers
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        companyName:
+          type: string
+        stage:
+          type: string
+        industry:
+          type: string
+          enum:
+            - BFSI
+            - Healthcare
+            - Retail
+            - EdTech
+            - Telecom
+            - SaaS
+            - Logistics
+            - Research / Biotech
+            - Other
+            - ""
+        location:
+          type: string
+        estimatedCallVolume:
+          type:
+            - number
+            - "null"
+        employeeCount:
+          type:
+            - number
+            - "null"
+        intent:
+          type: string
+          enum:
+            - ""
+            - Hot
+            - Cold
+            - Warm
+        offeredPrice:
+          type:
+            - number
+            - "null"
+        primaryContactId:
+          type:
+            - string
+            - "null"
+          format: uuid
+
+        assignedTo:
+          type: string
+
+        lastContacted:
+          type:
+            - string
+            - "null"
+          format: date-time
+        nextFollowUp:
+          type:
+            - string
+            - "null"
+          format: date-time
+        notes:
+          type: string
+        sourceLink:
+          type: string
+        companyWebsite:
+          type: string
+        linkedInCompany:
+          type: string
+        discoveryAnswers:
+          type: object
+          additionalProperties:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+    Contact:
+      type: object
+      required:
+       - id
+       - contactName
+       - companyId
+       - role
+       - phone
+       - email
+       - linkedInProfile
+       - contactStatus
+       - champion
+       - lastContacted
+       - nextFollowUp
+       - notes
+       - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        contactName:
+          type: string
+        companyId:
+          type:
+            - string
+            - "null"
+          format: uuid
+        role:
+          type: string
+        phone:
+          type: string
+        email:
+          type: string
+        linkedInProfile:
+          type: string
+        contactStatus:
+          type: string
+        champion:
+          type: boolean
+        lastContacted:
+          type:
+            - string
+            - "null"
+          format: date-time
+        nextFollowUp:
+          type:
+            - string
+            - "null"
+          format: date-time
+        notes:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+
     DiscoveryQuestion:
       type: object
       required:
@@ -522,4 +678,31 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+
+  /api/bootstrap:
+    get:
+      summary: Retrieve companies and contacts.
+      responses:
+        "200":
+          description: Returns all companies and contacts required to initialize the CRM application.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - companies
+                  - contacts
+                properties:
+                  companies:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Company"
+                  contacts:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Contact"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,135 @@
+openapi: 3.1.0
+
+info:
+  title: Zero Cost CRM API
+  version: 1.1.0
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+
+    DiscoveryQuestion:
+      type: object
+      required:
+        - id
+        - section
+        - prompt
+        - input
+      properties:
+        id:
+          type: string
+        section:
+          type: string
+        prompt:
+          type: string
+        input:
+          type: string
+          enum:
+            - text
+            - textarea
+            - number
+
+    ConfigResponse:
+      type: object
+      required:
+        - brandName
+        - brandTagline
+        - logoUrl
+        - stages
+        - contactStatuses
+        - championStatusToStage
+        - discoveryQuestions
+        - allowedEmailDomain
+        - allowedEmailDomains
+        - allowAnyEmailDomain
+      properties:
+
+        brandName:
+          type: string
+
+        brandTagline:
+          type: string
+
+        logoUrl:
+          type: string
+
+        stages:
+          type: array
+          items:
+            type: string
+
+        contactStatuses:
+          type: array
+          items:
+            type: string
+
+        championStatusToStage:
+          type: object
+          additionalProperties:
+            type:
+              - string
+              - "null"
+        discoveryQuestions:
+          type: array
+          items:
+            $ref: "#/components/schemas/DiscoveryQuestion"
+        allowedEmailDomain:
+          type:
+            - string
+            - "null"
+        allowedEmailDomains:
+          type: array
+          items:
+            type: string
+        allowAnyEmailDomain:
+          type: boolean
+
+
+
+paths:
+  /api/health:
+    get:
+      summary: Health check endpoint
+      responses:
+        "200":
+          description: Successful health check
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - ok
+                properties:
+                  ok:
+                    type: boolean
+                    description: Indicates whether the API server is healthy.
+                    example: true
+
+  /api/config:
+    get:
+      summary: Public instance configuration
+      responses:
+        "200":
+          description: Successful config response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConfigResponse"
+        "500":
+          description: Failed to load config
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -95,6 +95,76 @@ components:
             type: string
         allowAnyEmailDomain:
           type: boolean
+    SettingsPatch:
+      type: object
+      properties:
+        brandName:
+          type: string
+        brandTagline:
+          type: string
+        logoUrl:
+          type: string
+        stages:
+          type: array
+          items:
+            type: string
+        contactStatuses:
+          type: array
+          items:
+            type: string
+        championStatusToStage:
+          type: object
+          additionalProperties:
+            type:
+              - string
+              - "null"
+        discoveryQuestions:
+          type: array
+          items:
+            $ref: "#/components/schemas/DiscoveryQuestion"
+    SettingsResponse:
+      type: object
+      required:
+        - brandName
+        - brandTagline
+        - logoUrl
+        - stages
+        - contactStatuses
+        - championStatusToStage
+        - discoveryQuestions
+        - updatedAt
+      properties:
+        brandName:
+          type: string
+        brandTagline:
+          type: string
+        logoUrl:
+          type: string
+        stages:
+          type: array
+          items:
+            type: string
+        contactStatuses:
+          type: array
+          items:
+            type: string
+        championStatusToStage:
+          type: object
+          additionalProperties:
+            type:
+              - string
+              - "null"
+        discoveryQuestions:
+          type: array
+          items:
+            $ref: "#/components/schemas/DiscoveryQuestion"
+        updatedAt:
+          type:
+            - string
+            - "null"
+
+
+
 
 security:
   - bearerAuth: []
@@ -118,11 +188,9 @@ paths:
                     type: boolean
                     description: Indicates whether the API server is healthy.
                     example: true
-
   /api/config:
     get:
       security: []
-
       summary: Public instance configuration
       responses:
         "200":
@@ -133,6 +201,41 @@ paths:
                 $ref: "#/components/schemas/ConfigResponse"
         "500":
           description: Failed to load config
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/settings:
+    patch:
+      summary: Update application settings.
+      description: Requires an authenticated admin user.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SettingsPatch"
+      responses:
+        "200":
+          description: Application settings updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SettingsResponse"
+        "400":
+          description: Application settings failed. (Invalid settings)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Missing, Invalid or Expired Bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Missing Admin privileges.
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -425,7 +425,6 @@ components:
           format: date
         notes:
           type: string
-
     DiscoveryQuestion:
       type: object
       required:
@@ -659,7 +658,54 @@ components:
           type: integer
         closedLost:
           type: integer
-
+    Prospect:
+      type: object
+      properties:
+        company:
+          type: string
+        prospectName:
+          type: string
+        jobTitle:
+          type: string
+        email:
+          type: string
+          format: email
+        phone:
+          type: string
+        location:
+          type: string
+        employees:
+          type:
+            - integer
+            - "null"
+        industry:
+          type: string
+    ImportProspectsRequest:
+      type: object
+      required:
+        - rows
+      properties:
+        rows:
+          type: array
+          items:
+            $ref: "#/components/schemas/Prospect"
+    ImportProspectsResponse:
+      type:
+        object
+      required:
+        - companiesCreated
+        - companiesUpdated
+        - contactsCreated
+        - contactsSkipped
+      properties:
+        companiesCreated:
+          type: integer
+        companiesUpdated:
+          type: integer
+        contactsCreated:
+          type: integer
+        contactsSkipped:
+          type: integer
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
 
@@ -1045,3 +1091,23 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/import/prospects:
+    post:
+      summary: Bulk import prospects.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportProspectsRequest"
+      responses:
+        "200":
+          description: Import successful.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportProspectsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -212,6 +212,26 @@ components:
           type:
             - string
             - "null"
+    CreateUserRequest:
+      type: object
+      required:
+        - name
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          description: User email address.
+          format: email
+        name:
+          type: string
+          description: Name of the user.
+        password:
+          type: string
+          format: password
+          description: Minimum length; 8 characters.
+        role:
+          $ref: "#/components/schemas/UserRoles"
 
     LoginRequest:
       type: object
@@ -239,10 +259,6 @@ components:
           description: JWT bearer token
         user:
           $ref: "#/components/schemas/User"
-
-
-#_____________________ Security _____________________
-
     HeartBeatResponse:
       type: object
       required:
@@ -255,6 +271,30 @@ components:
         lastActiveAt:
           type: string
           format: date-time
+    UserResponse:
+      type: object
+      required:
+        - id
+        - email
+        - name
+        - role
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+        role:
+          $ref: "#/components/schemas/UserRoles"
+        createdAt:
+          type: string
+          format: date-time
+
+
 
 security: #as mentioned in API.md, all endpoints require auth
   - bearerAuth: []
@@ -429,4 +469,62 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
-
+  /api/users:
+    get:
+      summary: Retrives all users.
+      description: Requires an authenticated admin user.
+      responses:
+        "200":
+          description: Returns a list of all users.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - users
+                properties:
+                  users:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/UserResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      summary: Creates a new user.
+      description: Requires an authenticated admin user.
+      responses:
+        "201":
+          description: Returns the new user.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - user
+                properties:
+                  user:
+                    $ref: "#/components/schemas/UserResponse"
+        "400":
+          description: One or more of the fields have invalid data.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Email is already in use by another user.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateUserRequest"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,6 +12,14 @@ servers:
 
 components:
   parameters:
+    entityType:
+      name: entityType
+      in: path
+      required: true
+      description: Entity type
+      schema:
+        $ref: "#/components/schemas/EntityTypeSchema"
+
     id:
       name: id
       in: path
@@ -917,6 +925,22 @@ components:
         createdAt:
           type: string
           format: date-time
+    LeadHistoryResponse:
+      type: object
+      required:
+        - entityType
+        - entityId
+        - events
+      properties:
+        entityType:
+          $ref: "#/components/schemas/EntityTypeSchema"
+        entityId:
+          type: string
+          format: uuid
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/LeadHistoryEvent"
     TimelineEvent:
       type: object
       required:
@@ -963,6 +987,11 @@ components:
       enum:
         - contact.opened
         - company.opened
+    EntityTypeSchema:
+      type: string
+      enum:
+        - contact
+        - company
     CompanyHistoryResponse:
       type: object
       required:
@@ -1598,3 +1627,25 @@ paths:
           $ref: "#/components/responses/NotFound"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /api/activity/lead/{entityType}/{id}:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/id"
+        - $ref: "#/components/parameters/entityType"
+      summary: Retrieves activity for a lead.
+      responses:
+        "200":
+          description: Activity retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LeadHistoryResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+
+


### PR DESCRIPTION

## Summary

Adds an initial OpenAPI 3.1 specification for the HTTP API.

## Current coverage

- [x] OpenAPI file checked in and covers all documented routes in docs/API.md
- [x] Auth scheme and error shape ({ "error": "..." }) documented
- [x] README links to the spec
- [x] Spec validates (npx @redocly/cli lint openapi.yaml or equivalent) 

fixes #50 