### PR TITLE
docs: contributor onboarding polish (README / CONTRIBUTING / hall of fame)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,13 @@ npm run ci                # lint + format:check + unit + build
 
 ## Find something to work on
 
-1. Browse [good first issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) or [help wanted](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
-2. **Comment on the issue** to claim it (e.g. “I’d like to work on this”).
-3. Prefer one focused issue at a time.
+1. Prefer **[unassigned good first issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee)** so you’re not blocked on someone else’s claim.
+2. Want a showcase PR? Browse the **[`fun` label](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3Afun)** (command palette, empty states, docs GIF, etc.).
+3. Or pick any [help wanted](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) ticket.
+4. **Comment on the issue** to claim it (e.g. “I’d like to take this”). We’ll assign you — usually within a day.
+5. Prefer one focused issue at a time.
 
-If you’re new to open source, start with labels **`first-timers-only`**, **`good first issue`**, or **`easy`**.
+If you’re new to open source, start with labels **`first-timers-only`**, **`good first issue`**, or **`easy`**. Questions welcome in [Discussions](https://github.com/ConvoBrains/zero-cost-crm/discussions).
 
 ---
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,8 +2,20 @@
 
 People who have shipped meaningful improvements to Zero Cost CRM.
 
-| Name | Contribution                                                                                                                                                                                                                                       | LinkedIn |
-| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| —    | _First 10 meaningful contributors get early ConvoBrains QA access + a public shoutout. Comment on a [good first issue](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to get started._ | —        |
+| GitHub | Highlights |
+| ------ | ---------- |
+| [sc0rp10n-py](https://github.com/sc0rp10n-py) | Core product & platform contributions |
+| [nawazish2](https://github.com/nawazish2) | CONTRIBUTING expansion, Prettier, settings docs |
+| [itxhadi27-cmd](https://github.com/itxhadi27-cmd) | A11y Champion badge, Import Leads styling, Assigned To UX |
+| [Anmol-Sharma21](https://github.com/Anmol-Sharma21) | Champion pipeline auto-move, Escape/ARIA modals |
+| [Dodothereal](https://github.com/Dodothereal) | README Import Leads column accuracy |
+| [Insights388](https://github.com/Insights388) | Maintainer — pipeline/contacts UX, CI, bugfixes |
+| [ConvoBrains](https://github.com/ConvoBrains) | Maintainers |
 
-Maintainers will add your name + LinkedIn link after your PR merges.
+### Want your name here?
+
+1. Comment on an [unassigned good first issue](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee) (*I'd like to take this*).
+2. Open a focused PR — we review quickly.
+3. **First 10 meaningful contributors** get early access to **ConvoBrains QA** + a public shoutout ([details in #23](https://github.com/ConvoBrains/zero-cost-crm/issues/23)).
+
+Prefer a LinkedIn link next to your name? Say so in your PR or issue comment and maintainers will add it.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # Zero Cost CRM
 
-[![Open Source Helpers](https://www.codetriage.com/convobrains/zero-cost-crm/badges/users.svg)](https://www.codetriage.com/convobrains/zero-cost-crm)
+[![CI](https://github.com/ConvoBrains/zero-cost-crm/actions/workflows/ci.yml/badge.svg)](https://github.com/ConvoBrains/zero-cost-crm/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Good first issues](https://img.shields.io/github/labels/ConvoBrains/zero-cost-crm/good%20first%20issue)](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+[![GitHub stars](https://img.shields.io/github/stars/ConvoBrains/zero-cost-crm?style=social)](https://github.com/ConvoBrains/zero-cost-crm/stargazers)
 [![first-timers-only](https://img.shields.io/badge/first--timers--only-friendly-blue.svg?style=flat-square)](https://www.firsttimersonly.com/)
+[![Open Source Helpers](https://www.codetriage.com/convobrains/zero-cost-crm/badges/users.svg)](https://www.codetriage.com/convobrains/zero-cost-crm)
+
+**Salesforce for teams that still live in Sheets** — self-hosted pipeline, contacts, follow-ups, SDR activity, and optional call recordings. MIT. One command to run.
 
 **We don't need Salesforce. We need to know which SDR is converting and why.**
 
 Most early-stage B2B teams hire their first SDR and manage them on Google Sheets,
 scattered call recordings, and founder intuition. We built the system we wished existed.
 
-[Run locally](#run-it-in-3-steps) · [Architecture](docs/ARCHITECTURE.md) · [API](docs/API.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · **[Book a demo](https://www.convobrains.com/contact)**
+[Run locally](#run-it-in-3-steps) · [Good first issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · [Fun issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3Afun) · [Architecture](docs/ARCHITECTURE.md) · [API](docs/API.md) · [Contributing](CONTRIBUTING.md) · [Discussions](https://github.com/ConvoBrains/zero-cost-crm/discussions) · [Security](SECURITY.md) · **[Book a demo](https://www.convobrains.com/contact)**
+
+> **New here?** `make setup && make dev` → open [localhost:5173](http://localhost:5173) → pick an unassigned [good first issue](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee) → comment *I'd like to take this*. We review fast and mentor first-timers. Rewards: see [#23](https://github.com/ConvoBrains/zero-cost-crm/issues/23).
 
 ![Zero Cost CRM login](docs/images/login.png)
 
@@ -248,12 +256,25 @@ Google Fonts (DM Sans, Instrument Serif) are loaded from Google’s CDN under th
 
 ## Contributing
 
-[Good first issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · [CONTRIBUTING.md](CONTRIBUTING.md) · [CONTRIBUTORS.md](CONTRIBUTORS.md) · [CodeTriage](https://www.codetriage.com/convobrains/zero-cost-crm)
+We welcome first-time PRs. Maintainers aim to reply within a day on claimed issues.
+
+| Start here | Link |
+| --- | --- |
+| Beginner tickets | [good first issue](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee) (unassigned) |
+| Showcase / delightful work | [`fun` label](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3Afun) |
+| How to claim + ship | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Rewards + onboarding | [#23 Start here](https://github.com/ConvoBrains/zero-cost-crm/issues/23) |
+| Ideas & questions | [Discussions](https://github.com/ConvoBrains/zero-cost-crm/discussions) |
+| Hall of fame | [CONTRIBUTORS.md](CONTRIBUTORS.md) |
 
 ```bash
 make setup && make dev
 npm test
 ```
+
+<a href="https://github.com/ConvoBrains/zero-cost-crm/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=ConvoBrains/zero-cost-crm" alt="Contributors to Zero Cost CRM" />
+</a>
 
 ---
 


### PR DESCRIPTION
## Summary
- README: clearer pitch, badges, “New here?” CTA, links to unassigned good-first + `fun` issues + Discussions
- CONTRIBUTING: prefer unassigned issues; point at `fun` showcase work
- CONTRIBUTORS: list people who already shipped (was empty placeholder)

**No application code changes.**

Companion GitHub hygiene (already done on the repo, not in this PR):
- Unassigned shepherd from open beginner issues
- Added `fun` label + issues #68–#72
- Opened Discussions: First PR? Start here

## Test plan
- [ ] Skim README / CONTRIBUTING / CONTRIBUTORS on GitHub preview
- [ ] Confirm badge URLs resolve
- [ ] Confirm good-first / fun issue filter links work

Made with [Cursor](https://cursor.com)