### PR TITLE
fix: added aria-current="page" to Sidebar and MobileNav

### DIFF
--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -22,6 +22,7 @@ export function MobileNav({ page, onNavigate, userRole }: MobileNavProps) {
             <button
               key={item.id}
               type="button"
+              aria-current={active ? 'page' : undefined}
               onClick={() => onNavigate(item.id)}
               className={`flex min-h-14 flex-1 flex-col items-center justify-center gap-0.5 px-1 py-2 text-[10px] font-semibold transition ${
                 active ? 'text-teal-700' : 'text-stone-500'

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -43,6 +43,7 @@ export function Sidebar({
             <button
               key={item.id}
               type="button"
+              aria-current={active ? 'page' : undefined}
               onClick={() => onNavigate(item.id)}
               className={`rounded-none px-3 py-2.5 text-left transition ${
                 active ? 'bg-teal-700 text-white' : 'text-stone-700 hover:bg-stone-100'


### PR DESCRIPTION
## Summary
Added `aria-current="page"` to active Sidebar and MobileNav items. 

<!-- what & why -->

## Tests

- [X] `npm run lint` - passed 
- [X] `npm run format:check` - passed 
- [X] `npm test` - 74 passed, 1 pre-existing failure in `testing/unit/views.test.ts`
       - Confirmed the same test failed before this change
<img width="607" height="317" alt="Screenshot 2026-08-01 at 8 01 04 PM" src="https://github.com/user-attachments/assets/0816d486-4979-4d2d-adcd-3c56f228c94d" />

Fixes #16 