### PR TITLE
feat: add swagger-ui-express and yaml dependencies for API documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,9 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/convobrains_crm
 DB_SSL=false
 
 PORT=4000
-
+# Optional: Enable interactive API docs when running in production.
+# Docs are enabled automatically outside production.
+ENABLE_API_DOCS=false
 # Required — use a long random string (e.g. openssl rand -hex 32)
 JWT_SECRET=replace-with-a-long-random-value
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY server ./server
 COPY --from=builder /app/src ./src
 COPY sql ./sql
 COPY scripts ./scripts
+COPY openapi.yaml ./
 
 USER crm
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Important variables (see [`.env.example`](.env.example)):
 | ---------------------- | ---------------------------------------------------------------- |
 | `DATABASE_URL`         | Postgres connection string                                       |
 | `JWT_SECRET`           | **Required** — long random secret                                |
+| `ENABLE_API_DOCS`      | Optional — set `true` to expose Swagger UI at `/api/docs` in production |
 | `ALLOWED_EMAIL_DOMAIN` | Login allow-list (`convobrains.com`, comma list, or `*` for any) |
 | `CORS_ORIGINS`         | Allowed browser origins (comma-separated)                        |
 | `AWS_*`                | Optional — required only for call-recording uploads              |

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,6 +9,7 @@ Unless noted, endpoints require `Authorization: Bearer <jwt>`.
 A complete machine-readable OpenAPI 3.1 contract is available in [`openapi.yaml`](../openapi.yaml).
 
 ### How to view the spec
+- **Interactive UI**: Visit `/api/docs` when running the server locally (or set `ENABLE_API_DOCS=true` in production).
 - **Redocly CLI**: Run `npx @redocly/cli build-docs openapi.yaml` to generate an interactive HTML documentation bundle (`redoc-static.html`).
 - **Swagger Editor**: Copy [`openapi.yaml`](../openapi.yaml) into [editor.swagger.io](https://editor.swagger.io).
 - **VS Code Extension**: Use the *OpenAPI (Swagger) Editor* extension for live preview.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@types/pg": "^8.15.5",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@types/swagger-ui-express": "^4.1.8",
         "@vitejs/plugin-react": "^6.0.4",
         "concurrently": "^9.2.1",
         "oxlint": "^1.76.0",
@@ -2549,6 +2550,17 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,9 @@
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3",
         "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react-dom": "^19.2.7",
+        "swagger-ui-express": "^5.0.1",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.62.0",
@@ -1984,6 +1986,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@smithy/core": {
       "version": "3.31.1",
@@ -5647,6 +5656,30 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.12",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.12.tgz",
+      "integrity": "sha512-ceXE+KNc5LXafhh36trB6nxK+U2EIKUWzHT7sBiMosf2eJLAefalYnTwMouQBmSyED6m7Yz+GYZEcL+Glt3sww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
@@ -6356,6 +6389,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/pg": "^8.15.5",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/swagger-ui-express": "^4.1.8",
     "@vitejs/plugin-react": "^6.0.4",
     "concurrently": "^9.2.1",
     "oxlint": "^1.76.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.3",
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "swagger-ui-express": "^5.0.1",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.62.0",

--- a/server/app.ts
+++ b/server/app.ts
@@ -5,6 +5,7 @@ import rateLimit from 'express-rate-limit';
 import bcrypt from 'bcrypt';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { readFileSync } from 'node:fs';
 import { pool, companiesHaveDiscoveryAnswers } from './db.js';
 import { config, resolveCorsOrigin } from './config.js';
 import {
@@ -40,7 +41,8 @@ import {
   asDiscoveryQuestions,
   type SettingsPatch,
 } from './settings.js';
-
+import swaggerUi from 'swagger-ui-express';
+import YAML from 'yaml';
 const app = express();
 app.use(
   helmet({
@@ -72,6 +74,13 @@ app.use(
   })
 );
 app.use(express.json({ limit: '2mb' }));
+
+//serving interective API docs at /api/docs.
+if (config.enableApiDocs) {
+  const openapiPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'openapi.yaml');
+  const file = readFileSync(openapiPath, 'utf-8');
+  const swaggerDoc = YAML.parse(file);
+}
 
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,

--- a/server/app.ts
+++ b/server/app.ts
@@ -75,11 +75,12 @@ app.use(
 );
 app.use(express.json({ limit: '2mb' }));
 
-//serving interective API docs at /api/docs.
+// Serving interactive API docs at /api/docs.
 if (config.enableApiDocs) {
   const openapiPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'openapi.yaml');
   const file = readFileSync(openapiPath, 'utf-8');
   const swaggerDoc = YAML.parse(file);
+  app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerDoc));
 }
 
 const loginLimiter = rateLimit({

--- a/server/app.ts
+++ b/server/app.ts
@@ -77,10 +77,22 @@ app.use(express.json({ limit: '2mb' }));
 
 // Serving interactive API docs at /api/docs.
 if (config.enableApiDocs) {
-  const openapiPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'openapi.yaml');
-  const file = readFileSync(openapiPath, 'utf-8');
-  const swaggerDoc = YAML.parse(file);
-  app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerDoc));
+  try {
+    const openapiPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'openapi.yaml');
+    const file = readFileSync(openapiPath, 'utf-8');
+    const swaggerDoc = YAML.parse(file);
+    app.use(
+      '/api/docs',
+      (_req, res, next) => {
+        res.removeHeader('Content-Security-Policy');
+        next();
+      },
+      swaggerUi.serve,
+      swaggerUi.setup(swaggerDoc)
+    );
+  } catch (err) {
+    console.warn("[DOCS] openapi.yaml file not found or could not be loaded.",err)
+  }
 }
 
 const loginLimiter = rateLimit({

--- a/server/app.ts
+++ b/server/app.ts
@@ -83,7 +83,7 @@ if (config.enableApiDocs) {
     const swaggerDoc = YAML.parse(file);
     app.use(
       '/api/docs',
-      (_req, res, next) => {
+      (_req: express.Request, res: express.Response, next: express.NextFunction) => {
         res.removeHeader('Content-Security-Policy');
         next();
       },

--- a/server/config.ts
+++ b/server/config.ts
@@ -22,6 +22,7 @@ function parseList(raw: string | undefined): string[] {
 const nodeEnv = read('NODE_ENV') ?? 'development';
 const isProd = nodeEnv === 'production';
 const isTest = nodeEnv === 'test' || read('ALLOW_ACTIVITY_SEED') === '1';
+const enableApiDocs = !isProd || read('ENABLE_API_DOCS') === 'true';
 
 function requireJwtSecret(): string {
   const secret = read('JWT_SECRET');
@@ -55,6 +56,7 @@ export const config = {
   nodeEnv,
   isProd,
   isTest,
+  enableApiDocs,
   port: Number(read('PORT') ?? 4000),
   jwtSecret: requireJwtSecret(),
   allowedEmailAny: emailPolicy.any,

--- a/testing/functional/api/docs.test.ts
+++ b/testing/functional/api/docs.test.ts
@@ -1,0 +1,36 @@
+import type { AddressInfo } from 'node:net';
+import { describe, expect, it } from 'vitest';
+import { api } from './helpers';
+import { config } from '../../../server/config.js';
+
+describe('interactive API docs (/api/docs)', () => {
+  it('serves Swagger UI when docs are enabled', async () => {
+    const res = await api<string>('/api/docs');
+    expect(res.status).toBe(200);
+    expect(res.data).toContain('Swagger UI');
+  });
+
+  it('is absent (404) when docs are disabled in production', async () => {
+    (config as { enableApiDocs: boolean }).enableApiDocs = false;
+    try {
+      const { default: prodApp } = await import(
+        /* @vite-ignore */ `../../../server/app.js?test=prod-disabled-${Date.now()}`
+      );
+
+      const server = await new Promise<import('node:http').Server>((resolve, reject) => {
+        const s = prodApp.listen(0, '127.0.0.1', () => resolve(s));
+        s.on('error', reject);
+      });
+      const { port } = server.address() as AddressInfo;
+
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/api/docs`);
+        expect(res.status).toBe(404);
+      } finally {
+        server.close();
+      }
+    } finally {
+      (config as { enableApiDocs: boolean }).enableApiDocs = true;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Serving the swagger UI at /api/docs using the openapi.yaml in pr #67.
 
## Checklist
- [x] GET /api/docs shows interactive docs locally after make dev
- [x] Production keeps docs off unless explicitly enabled
- [x] README or docs/API.md mentions how to open it
- [x] No secrets leaked into the spec
___
fixes #70 