### PR TITLE
fix(contacts): make desktop rows keyboard accessible

### DIFF
--- a/src/components/Contacts.tsx
+++ b/src/components/Contacts.tsx
@@ -588,6 +588,13 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
                   <tr
                     key={t.id}
                     onClick={() => openContact(t)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        openContact(t);
+                      }
+                    }}
+                    tabIndex={0}
                     className="cursor-pointer border-b border-[var(--color-line)]/70 transition hover:bg-teal-50/40"
                   >
                     <td className="px-4 py-3">


### PR DESCRIPTION
## Summary

Make desktop Contacts table rows keyboard accessible.

- Rows can be reached using Tab.
- Enter and Space open the contact edit modal.
- Existing mouse interaction is preserved.
- Mobile contact buttons are unchanged.

Closes #14

## Tests

- [x] `npm run build`
- [x] `git diff --check`
- [ ] E2E tests

## Checklist

- [x] No secrets / PII
- [ ] CI green