### PR TITLE
fix: make pipeline last-30-days unit test date-stable

### DIFF
--- a/testing/unit/views.test.ts
+++ b/testing/unit/views.test.ts
@@ -6,6 +6,7 @@ import {
   buildPipelineInsights,
   dateRangeStartIso,
   filterCompanies,
+  isoDateOffset,
   startOfMonthIso,
   startOfWeekIso,
   todayIso,
@@ -315,6 +316,7 @@ describe('applyPipelineFilters', () => {
     customTo: null,
   };
 
+  const midCreated = isoDateOffset(-10);
   const companies = [
     company({
       id: '1',
@@ -332,7 +334,7 @@ describe('applyPipelineFilters', () => {
       id: '3',
       companyName: 'Mid Follow',
       stage: 'Follow-up',
-      createdAt: '2026-07-01T00:00:00.000Z',
+      createdAt: `${midCreated}T00:00:00.000Z`,
     }),
   ];
 
@@ -351,8 +353,8 @@ describe('applyPipelineFilters', () => {
     expect(
       applyPipelineFilters(companies, 'All Companies', {
         dateRange: 'custom',
-        customFrom: '2026-07-01',
-        customTo: '2026-07-01',
+        customFrom: midCreated,
+        customTo: midCreated,
       }).map((c) => c.id)
     ).toEqual(['3']);
 


### PR DESCRIPTION
## Summary
- Unit test `applyPipelineFilters` last-30-days expected `['1','3']` but got `['1']` because company 3 used a hard-coded `2026-07-01` `createdAt`.
- That date was inside the 30-day window when #44 merged (25 Jul 2026). By 2 Sep 2026 it is ~63 days old, so the rolling filter correctly drops it.
- Fixture now uses `isoDateOffset(-10)` so the test stays valid as calendar time moves.

## Why this was already on main
The test was **correct at merge time**. Later PRs (#67, #75, #26, #87) landed while CI on `main` was already red (UNSTABLE / mergeable-with-failing-checks), so the time-bomb was never caught before merge.

## Test plan
- [x] `npx vitest run --config vitest.config.ts` — 75/75 pass
- [x] `npm run lint`
- [x] `npm run build`


Made with [Cursor](https://cursor.com)