### PR TITLE
feat: Settings UI editor for championStatusToStage mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Settings UI editor for `championStatusToStage` (add/remove champion status → pipeline stage rows, saved via `PATCH /api/settings`)
+- `PATCH /api/settings` rejects champion maps whose keys/values are not in the configured contact statuses / stages
 - Instance `app_settings` table for branding, pipeline stages, and contact statuses (DB-backed; keeps the product generic across deploys)
 - `GET /api/config` now returns `brandName`, `brandTagline`, `logoUrl`, `stages`, `contactStatuses`, `championStatusToStage`
 - `PATCH /api/settings` (admin/founder) to update instance settings

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ scattered call recordings, and founder intuition. We built the system we wished 
 
 [Run locally](#run-it-in-3-steps) · [Good first issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) · [Fun issues](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3Afun) · [Architecture](docs/ARCHITECTURE.md) · [API](docs/API.md) · [OpenAPI](openapi.yaml) · [Contributing](CONTRIBUTING.md) · [Discussions](https://github.com/ConvoBrains/zero-cost-crm/discussions) · [Security](SECURITY.md) · **[Book a demo](https://www.convobrains.com/contact)**
 
-> **New here?** `make setup && make dev` → open [localhost:5173](http://localhost:5173) → pick an unassigned [good first issue](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee) → comment *I'd like to take this*. We review fast and mentor first-timers. Rewards: see [#23](https://github.com/ConvoBrains/zero-cost-crm/issues/23).
+> **New here?** `make setup && make dev` → open [localhost:5173](http://localhost:5173) → pick an unassigned [good first issue](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee) → comment _I'd like to take this_. We review fast and mentor first-timers. Rewards: see [#23](https://github.com/ConvoBrains/zero-cost-crm/issues/23).
 
 ![Zero Cost CRM login](docs/images/login.png)
 
@@ -105,32 +105,32 @@ Skip it if you need enterprise CPQ, multi-currency ERP integrations, or a full m
 
 ## What's in Zero Cost CRM
 
-| Capability            | What you get                                         |
-| --------------------- | ---------------------------------------------------- |
-| **Live dashboard**    | Follow-ups due, demos, active opps, won/lost         |
-| **13-stage pipeline** | Drag deals from lead → closed                        |
-| **Contacts**          | Champions, statuses, notes, LinkedIn                 |
-| **Paste import**      | Excel / Sheets / CSV → deduped companies + contacts  |
-| **Call recordings**   | Upload & play audio per contact (S3 optional)        |
-| **SDR activity**      | Logins, active/idle time, outcomes, targets          |
-| **Manager alerts**    | No login by 10:30, zero connects, missing follow-ups |
-| **Roles**             | Founder / admin / SDR                                |
-| **Self-hosted**       | Your Postgres, your rules                            |
-| **Instance settings** | Brand name, stages, statuses in DB (Settings UI)     |
+| Capability            | What you get                                                  |
+| --------------------- | ------------------------------------------------------------- |
+| **Live dashboard**    | Follow-ups due, demos, active opps, won/lost                  |
+| **13-stage pipeline** | Drag deals from lead → closed                                 |
+| **Contacts**          | Champions, statuses, notes, LinkedIn                          |
+| **Paste import**      | Excel / Sheets / CSV → deduped companies + contacts           |
+| **Call recordings**   | Upload & play audio per contact (S3 optional)                 |
+| **SDR activity**      | Logins, active/idle time, outcomes, targets                   |
+| **Manager alerts**    | No login by 10:30, zero connects, missing follow-ups          |
+| **Roles**             | Founder / admin / SDR                                         |
+| **Self-hosted**       | Your Postgres, your rules                                     |
+| **Instance settings** | Brand, stages, statuses, champion auto-move map (Settings UI) |
 
 ### Configuring your instance
 
 Keep the **code** generic. Put company-specific values in env or the database:
 
-| What                                                | Where                                                                             |
-| --------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Postgres / JWT / email domain / S3 / CORS           | Server `.env` (`DATABASE_URL`, `JWT_SECRET`, `ALLOWED_EMAIL_DOMAIN`, …)           |
-| Brand name, logo, pipeline stages, contact statuses | DB `app_settings` — edit in **Settings** (founder/admin) or `PATCH /api/settings` |
-| Champion status → pipeline stage map (`championStatusToStage`) | **API / SQL only** today — `PATCH /api/settings` or [`sql/examples/convobrains-settings.sql`](sql/examples/convobrains-settings.sql) |
-| Discovery questions on the company form (`discoveryQuestions`) | **API / SQL only** today — same as above (not editable in the Settings UI yet) |
-| Optional first-boot brand | `BRAND_NAME`, `BRAND_TAGLINE`, `BRAND_LOGO_URL` in env (seeded once) |
+| What                                                           | Where                                                                                                                                                                      |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Postgres / JWT / email domain / S3 / CORS                      | Server `.env` (`DATABASE_URL`, `JWT_SECRET`, `ALLOWED_EMAIL_DOMAIN`, …)                                                                                                    |
+| Brand name, logo, pipeline stages, contact statuses            | DB `app_settings` — edit in **Settings** (founder/admin) or `PATCH /api/settings`                                                                                          |
+| Champion status → pipeline stage map (`championStatusToStage`) | DB `app_settings` — edit in **Settings** (founder/admin) or `PATCH /api/settings`                                                                                          |
+| Discovery questions on the company form (`discoveryQuestions`) | **API / SQL only** today — `PATCH /api/settings` or [`sql/examples/convobrains-settings.sql`](sql/examples/convobrains-settings.sql) (not editable in the Settings UI yet) |
+| Optional first-boot brand                                      | `BRAND_NAME`, `BRAND_TAGLINE`, `BRAND_LOGO_URL` in env (seeded once)                                                                                                       |
 
-Settings UI covers branding + stages + contact statuses. The champion sync map and discovery questions still go through the API (or the SQL example). See [`docs/API.md`](docs/API.md#settings-ui-vs-api-only) for a `PATCH` example.
+Settings UI covers branding, stages, contact statuses, and the champion auto-move map. Discovery questions still go through the API (or the SQL example). See [`docs/API.md`](docs/API.md#settings-ui-vs-api-only) for a `PATCH` example. Keys/values in the champion map must exist in the configured status and stage lists.
 
 ---
 
@@ -258,14 +258,14 @@ Google Fonts (DM Sans, Instrument Serif) are loaded from Google’s CDN under th
 
 We welcome first-time PRs. Maintainers aim to reply within a day on claimed issues.
 
-| Start here | Link |
-| --- | --- |
-| Beginner tickets | [good first issue](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee) (unassigned) |
-| Showcase / delightful work | [`fun` label](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3Afun) |
-| How to claim + ship | [CONTRIBUTING.md](CONTRIBUTING.md) |
-| Rewards + onboarding | [#23 Start here](https://github.com/ConvoBrains/zero-cost-crm/issues/23) |
-| Ideas & questions | [Discussions](https://github.com/ConvoBrains/zero-cost-crm/discussions) |
-| Hall of fame | [CONTRIBUTORS.md](CONTRIBUTORS.md) |
+| Start here                 | Link                                                                                                                                                     |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Beginner tickets           | [good first issue](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+no%3Aassignee) (unassigned) |
+| Showcase / delightful work | [`fun` label](https://github.com/ConvoBrains/zero-cost-crm/issues?q=is%3Aissue+is%3Aopen+label%3Afun)                                                    |
+| How to claim + ship        | [CONTRIBUTING.md](CONTRIBUTING.md)                                                                                                                       |
+| Rewards + onboarding       | [#23 Start here](https://github.com/ConvoBrains/zero-cost-crm/issues/23)                                                                                 |
+| Ideas & questions          | [Discussions](https://github.com/ConvoBrains/zero-cost-crm/discussions)                                                                                  |
+| Hall of fame               | [CONTRIBUTORS.md](CONTRIBUTORS.md)                                                                                                                       |
 
 ```bash
 make setup && make dev

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,9 +9,10 @@ Unless noted, endpoints require `Authorization: Bearer <jwt>`.
 A complete machine-readable OpenAPI 3.1 contract is available in [`openapi.yaml`](../openapi.yaml).
 
 ### How to view the spec
+
 - **Redocly CLI**: Run `npx @redocly/cli build-docs openapi.yaml` to generate an interactive HTML documentation bundle (`redoc-static.html`).
 - **Swagger Editor**: Copy [`openapi.yaml`](../openapi.yaml) into [editor.swagger.io](https://editor.swagger.io).
-- **VS Code Extension**: Use the *OpenAPI (Swagger) Editor* extension for live preview.
+- **VS Code Extension**: Use the _OpenAPI (Swagger) Editor_ extension for live preview.
 
 ## Public
 
@@ -19,7 +20,7 @@ A complete machine-readable OpenAPI 3.1 contract is available in [`openapi.yaml`
 | ------- | --------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `GET`   | `/api/health`   | Liveness `{ ok: true }`                                                                                             |
 | `GET`   | `/api/config`   | Public instance config: email policy + branding, stages, contactStatuses, championStatusToStage, discoveryQuestions |
-| `PATCH` | `/api/settings` | Admin/founder: update branding + stages + contactStatuses (+ optional champion map / discoveryQuestions)            |
+| `PATCH` | `/api/settings` | Admin/founder: update branding + stages + contactStatuses + champion map (+ optional discoveryQuestions)            |
 
 ### Settings UI vs API-only
 
@@ -28,15 +29,13 @@ The **Settings** page in the app can edit:
 - `brandName`, `brandTagline`, `logoUrl`
 - `stages` (pipeline)
 - `contactStatuses`
+- `championStatusToStage` (champion contact status → pipeline stage auto-move)
 
-These two are **not** on that page yet (easy to miss — they’re not broken, just API/SQL only):
+`discoveryQuestions` is **not** on that page yet (easy to miss: not broken, just API/SQL only). Extra questions on the company form use `{ id, section, prompt, input }`.
 
-| Field | Purpose |
-| ----- | ------- |
-| `championStatusToStage` | When a champion’s contact status changes, optionally move the company to a pipeline stage |
-| `discoveryQuestions` | Extra questions shown on the company form (`id`, `section`, `prompt`, `input`) |
+Keys in `championStatusToStage` must be configured contact statuses. Values must be a configured pipeline stage or `null` (no auto-move). Unknown pairs return `400`.
 
-Change them with `PATCH /api/settings` (founder/admin JWT) or seed via [`sql/examples/convobrains-settings.sql`](../sql/examples/convobrains-settings.sql).
+Change discovery questions (or the map via API) with `PATCH /api/settings` (founder/admin JWT) or seed via [`sql/examples/convobrains-settings.sql`](../sql/examples/convobrains-settings.sql).
 
 ```bash
 curl -s -X PATCH http://localhost:4000/api/settings \
@@ -44,8 +43,8 @@ curl -s -X PATCH http://localhost:4000/api/settings \
   -H "Content-Type: application/json" \
   -d '{
     "championStatusToStage": {
-      "Connected - Booked a Discovery Call": "Discovery Call Done",
-      "Interested": "Follow-up"
+      "Interested": "Discovery Call Done",
+      "Follow-up Required": "Follow-up"
     },
     "discoveryQuestions": [
       {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -595,6 +595,7 @@ components:
             type: string
         championStatusToStage:
           type: object
+          description: Keys must be configured contactStatuses; values must be a configured stage or null.
           additionalProperties:
             type:
               - string
@@ -1309,7 +1310,7 @@ paths:
     patch:
       operationId: updateSettings
       summary: Update application settings.
-      description: Requires an authenticated admin user.
+      description: Requires an authenticated admin or founder. championStatusToStage keys must exist in contactStatuses; values must be a configured stage or null.
       requestBody:
         required: true
         content:

--- a/server/app.ts
+++ b/server/app.ts
@@ -178,10 +178,27 @@ app.patch('/api/settings', requireAuth, requireAdmin, async (req, res) => {
   if (Array.isArray(b.contactStatuses)) {
     patch.contactStatuses = b.contactStatuses.filter((x): x is string => typeof x === 'string');
   }
-  if (b.championStatusToStage && typeof b.championStatusToStage === 'object') {
+  if (b.championStatusToStage !== undefined) {
+    if (
+      b.championStatusToStage === null ||
+      typeof b.championStatusToStage !== 'object' ||
+      Array.isArray(b.championStatusToStage)
+    ) {
+      res.status(400).json({
+        error: 'championStatusToStage must be an object map of contact status to pipeline stage.',
+      });
+      return;
+    }
     const map: Record<string, string | null> = {};
     for (const [k, v] of Object.entries(b.championStatusToStage as Record<string, unknown>)) {
-      if (v === null || typeof v === 'string') map[k] = v;
+      if (v === null || typeof v === 'string') {
+        map[k] = v;
+      } else {
+        res.status(400).json({
+          error: `championStatusToStage["${k}"] must be a stage name or null.`,
+        });
+        return;
+      }
     }
     patch.championStatusToStage = map;
   }

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -15,6 +15,7 @@ import {
   type DiscoveryInputType,
   type DiscoveryQuestion,
 } from '../src/defaults.js';
+import { validateChampionStatusToStage } from '../src/lib/championStatusMap.js';
 
 export interface AppSettings {
   brandName: string;
@@ -191,11 +192,12 @@ export async function updateAppSettings(patch: SettingsPatch): Promise<AppSettin
   const statusErr = validateNonEmptyStrings('contactStatuses', next.contactStatuses);
   if (statusErr) throw new Error(statusErr);
 
-  for (const [status, stage] of Object.entries(next.championStatusToStage)) {
-    if (stage != null && !next.stages.includes(stage)) {
-      throw new Error(`championStatusToStage["${status}"] targets unknown stage "${stage}".`);
-    }
-  }
+  const mapErr = validateChampionStatusToStage(
+    next.championStatusToStage,
+    next.contactStatuses,
+    next.stages
+  );
+  if (mapErr) throw new Error(mapErr);
 
   await ensureAppSettings();
   const { rows } = await pool.query(

--- a/src/components/ChampionMapEditor.tsx
+++ b/src/components/ChampionMapEditor.tsx
@@ -1,0 +1,121 @@
+import { btnGhost, inputClass } from './ui';
+import { unusedContactStatuses, type ChampionMapRow } from '../lib/championStatusMap';
+
+interface ChampionMapEditorProps {
+  rows: ChampionMapRow[];
+  contactStatuses: string[];
+  stages: string[];
+  onChange: (rows: ChampionMapRow[]) => void;
+}
+
+export function ChampionMapEditor({
+  rows,
+  contactStatuses,
+  stages,
+  onChange,
+}: ChampionMapEditorProps) {
+  const unused = unusedContactStatuses(contactStatuses, rows);
+  const canAdd = unused.length > 0 && stages.length > 0;
+
+  const updateRow = (id: string, patch: Partial<ChampionMapRow>) => {
+    onChange(rows.map((row) => (row.id === id ? { ...row, ...patch } : row)));
+  };
+
+  const addRow = () => {
+    if (!canAdd) return;
+    const status = unused[0] ?? '';
+    const stage = stages[0] ?? '';
+    onChange([...rows, { id: `champion-map-new-${rows.length}-${status}`, status, stage }]);
+  };
+
+  return (
+    <section data-testid="champion-map-editor" aria-labelledby="champion-map-heading">
+      <h2 id="champion-map-heading" className="text-sm font-medium text-stone-600">
+        Champion status → pipeline stage
+      </h2>
+      <p className="mt-1 text-xs text-stone-500">
+        When a champion&apos;s contact status changes, the company can move forward to the mapped
+        pipeline stage. Companies never move backward, and Closed Won / Closed Lost are never
+        auto-moved. Statuses without a row stay put.
+      </p>
+
+      {rows.length === 0 ? (
+        <p className="mt-3 text-sm text-stone-500" data-testid="champion-map-empty">
+          No auto-move mappings yet. Add a row to move a company when its champion hits a status.
+        </p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {rows.map((row) => {
+            const statusOptions = unusedContactStatuses(contactStatuses, rows, row.status);
+            if (row.status && !statusOptions.includes(row.status)) {
+              statusOptions.unshift(row.status);
+            }
+            const stageOptions =
+              row.stage && !stages.includes(row.stage) ? [row.stage, ...stages] : stages;
+
+            return (
+              <li
+                key={row.id}
+                data-testid="champion-map-row"
+                className="grid grid-cols-1 items-end gap-2 sm:grid-cols-[1fr_auto_1fr_auto]"
+              >
+                <label className="flex min-w-0 flex-col gap-1.5 text-sm">
+                  <span className="text-xs font-medium text-stone-500">Contact status</span>
+                  <select
+                    className={inputClass}
+                    value={row.status}
+                    onChange={(e) => updateRow(row.id, { status: e.target.value })}
+                    aria-label="Contact status"
+                  >
+                    {statusOptions.map((status) => (
+                      <option key={status} value={status}>
+                        {contactStatuses.includes(status) ? status : `${status} (not in list)`}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <span aria-hidden className="hidden pb-3 text-xs text-stone-400 sm:inline">
+                  →
+                </span>
+                <label className="flex min-w-0 flex-col gap-1.5 text-sm">
+                  <span className="text-xs font-medium text-stone-500">Pipeline stage</span>
+                  <select
+                    className={inputClass}
+                    value={row.stage}
+                    onChange={(e) => updateRow(row.id, { stage: e.target.value })}
+                    aria-label="Pipeline stage"
+                  >
+                    {stageOptions.map((stage) => (
+                      <option key={stage} value={stage}>
+                        {stages.includes(stage) ? stage : `${stage} (not in list)`}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  className={btnGhost}
+                  data-testid="champion-map-remove"
+                  aria-label={`Remove mapping for ${row.status || 'this status'}`}
+                  onClick={() => onChange(rows.filter((r) => r.id !== row.id))}
+                >
+                  Remove
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <button
+        type="button"
+        className={`${btnGhost} mt-3`}
+        data-testid="champion-map-add"
+        disabled={!canAdd}
+        onClick={addRow}
+      >
+        Add mapping
+      </button>
+    </section>
+  );
+}

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import type { AppConfig } from '../types';
 import { api } from '../lib/api';
+import {
+  championMapToRows,
+  championRowsToMap,
+  validateChampionMapRows,
+  type ChampionMapRow,
+} from '../lib/championStatusMap';
+import { ChampionMapEditor } from './ChampionMapEditor';
 import { Field, inputClass, btnPrimary, btnGhost } from './ui';
 
 interface SettingsPageProps {
@@ -21,6 +28,9 @@ export function SettingsPage({ config, onSaved }: SettingsPageProps) {
   const [logoUrl, setLogoUrl] = useState(config.logoUrl);
   const [stagesText, setStagesText] = useState(config.stages.join('\n'));
   const [statusesText, setStatusesText] = useState(config.contactStatuses.join('\n'));
+  const [mapRows, setMapRows] = useState<ChampionMapRow[]>(() =>
+    championMapToRows(config.championStatusToStage)
+  );
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -31,6 +41,7 @@ export function SettingsPage({ config, onSaved }: SettingsPageProps) {
     setLogoUrl(config.logoUrl);
     setStagesText(config.stages.join('\n'));
     setStatusesText(config.contactStatuses.join('\n'));
+    setMapRows(championMapToRows(config.championStatusToStage));
   }, [config]);
 
   const domainHint = useMemo(() => {
@@ -39,20 +50,29 @@ export function SettingsPage({ config, onSaved }: SettingsPageProps) {
     return 'Configured via env ALLOWED_EMAIL_DOMAIN';
   }, [config]);
 
+  const liveStatuses = linesToList(statusesText);
+  const liveStages = linesToList(stagesText);
+
   const submit = async (e: FormEvent) => {
     e.preventDefault();
     setSaving(true);
     setError(null);
     setMessage(null);
     try {
+      const mapError = validateChampionMapRows(mapRows, liveStatuses, liveStages);
+      if (mapError) {
+        setError(mapError);
+        return;
+      }
       await api('/api/settings', {
         method: 'PATCH',
         body: JSON.stringify({
           brandName,
           brandTagline,
           logoUrl,
-          stages: linesToList(stagesText),
-          contactStatuses: linesToList(statusesText),
+          stages: liveStages,
+          contactStatuses: liveStatuses,
+          championStatusToStage: championRowsToMap(mapRows),
         }),
       });
       await onSaved();
@@ -65,19 +85,16 @@ export function SettingsPage({ config, onSaved }: SettingsPageProps) {
   };
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6">
+    <div className="mx-auto max-w-3xl space-y-6">
       <div>
         <h1 className="text-xl font-semibold text-stone-900">Instance settings</h1>
         <p className="mt-1 text-sm text-stone-500">
-          Branding and pipeline lists are stored in the database so Zero Cost CRM stays generic.
-          Email domain and database URL stay in server env.
+          Branding, pipeline lists, and champion auto-move mappings are stored in the database so
+          Zero Cost CRM stays generic. Email domain and database URL stay in server env.
         </p>
         <p className="mt-2 text-xs text-stone-500">
-          Champion status → stage mapping and discovery questions aren&apos;t on this
-          screen yet — update them with{' '}
-          <code className="rounded bg-stone-100 px-1 py-0.5 text-[11px]">
-            PATCH /api/settings
-          </code>{' '}
+          Discovery questions aren&apos;t on this screen yet. Update them with{' '}
+          <code className="rounded bg-stone-100 px-1 py-0.5 text-[11px]">PATCH /api/settings</code>{' '}
           or see{' '}
           <a
             className="underline decoration-stone-300 underline-offset-2 hover:text-stone-700"
@@ -135,9 +152,20 @@ export function SettingsPage({ config, onSaved }: SettingsPageProps) {
           />
         </Field>
 
+        <ChampionMapEditor
+          rows={mapRows}
+          contactStatuses={liveStatuses}
+          stages={liveStages}
+          onChange={setMapRows}
+        />
+
         <p className="text-xs text-stone-500">Login email policy: {domainHint}</p>
 
-        {error ? <p className="text-sm text-rose-700">{error}</p> : null}
+        {error ? (
+          <p className="text-sm text-rose-700" role="alert">
+            {error}
+          </p>
+        ) : null}
         {message ? <p className="text-sm text-teal-800">{message}</p> : null}
 
         <div className="flex gap-2">
@@ -153,6 +181,7 @@ export function SettingsPage({ config, onSaved }: SettingsPageProps) {
               setLogoUrl(config.logoUrl);
               setStagesText(config.stages.join('\n'));
               setStatusesText(config.contactStatuses.join('\n'));
+              setMapRows(championMapToRows(config.championStatusToStage));
               setError(null);
               setMessage(null);
             }}

--- a/src/lib/championStatusMap.ts
+++ b/src/lib/championStatusMap.ts
@@ -1,0 +1,96 @@
+/** Champion contact status → pipeline stage auto-move map helpers. */
+
+export type ChampionStatusToStage = Record<string, string | null>;
+
+export interface ChampionMapRow {
+  id: string;
+  status: string;
+  stage: string;
+}
+
+let rowSeq = 0;
+
+function nextRowId(status: string): string {
+  rowSeq += 1;
+  return `champion-map-${rowSeq}-${status || 'new'}`;
+}
+
+/** Visible editor rows: only statuses that actually auto-move (non-null stage). */
+export function championMapToRows(map: ChampionStatusToStage): ChampionMapRow[] {
+  const rows: ChampionMapRow[] = [];
+  for (const [status, stage] of Object.entries(map)) {
+    if (typeof stage !== 'string' || !stage.trim()) continue;
+    rows.push({ id: nextRowId(status), status, stage });
+  }
+  return rows;
+}
+
+export function championRowsToMap(rows: ChampionMapRow[]): ChampionStatusToStage {
+  const map: ChampionStatusToStage = {};
+  for (const row of rows) {
+    const status = row.status.trim();
+    const stage = row.stage.trim();
+    if (!status || !stage) continue;
+    map[status] = stage;
+  }
+  return map;
+}
+
+export function unusedContactStatuses(
+  contactStatuses: readonly string[],
+  rows: ChampionMapRow[],
+  currentStatus = ''
+): string[] {
+  const used = new Set(rows.map((row) => row.status).filter((status) => status !== currentStatus));
+  return contactStatuses.filter((status) => !used.has(status));
+}
+
+/**
+ * Reject maps whose keys/values are not in the configured lists.
+ * Null targets are allowed (explicit no auto-move).
+ */
+export function validateChampionStatusToStage(
+  map: ChampionStatusToStage,
+  contactStatuses: readonly string[],
+  stages: readonly string[]
+): string | null {
+  const statusSet = new Set(contactStatuses);
+  const stageSet = new Set(stages);
+
+  for (const [rawStatus, stage] of Object.entries(map)) {
+    const status = rawStatus.trim();
+    if (!status) {
+      return 'championStatusToStage keys must be non-empty.';
+    }
+    if (!statusSet.has(rawStatus) && !statusSet.has(status)) {
+      return `championStatusToStage key "${rawStatus}" is not a configured contact status.`;
+    }
+    if (stage == null) continue;
+    if (typeof stage !== 'string' || !stage.trim()) {
+      return `championStatusToStage["${rawStatus}"] must be a pipeline stage or null.`;
+    }
+    if (!stageSet.has(stage) && !stageSet.has(stage.trim())) {
+      return `championStatusToStage["${rawStatus}"] targets unknown stage "${stage}".`;
+    }
+  }
+  return null;
+}
+
+export function validateChampionMapRows(
+  rows: ChampionMapRow[],
+  contactStatuses: readonly string[],
+  stages: readonly string[]
+): string | null {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const status = row.status.trim();
+    const stage = row.stage.trim();
+    if (!status) return 'Each mapping needs a contact status.';
+    if (!stage) return 'Each mapping needs a pipeline stage.';
+    if (seen.has(status)) {
+      return `Contact status "${status}" is mapped more than once.`;
+    }
+    seen.add(status);
+  }
+  return validateChampionStatusToStage(championRowsToMap(rows), contactStatuses, stages);
+}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -22,7 +22,7 @@ export const NAV_ITEMS: {
   {
     id: 'settings',
     label: 'Settings',
-    hint: 'Brand · stages · statuses',
+    hint: 'Brand · stages · champion map',
     short: 'Settings',
     adminOnly: true,
   },

--- a/testing/e2e/auth.spec.ts
+++ b/testing/e2e/auth.spec.ts
@@ -4,7 +4,7 @@ import { gotoLogin, loginAsFounder, SEED } from './helpers';
 test.describe('Auth (UI)', () => {
   test('founder logs in and reaches dashboard', async ({ page }) => {
     await loginAsFounder(page);
-    await expect(page.getByRole('heading', { name: 'SDR Dashboard' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
     await expect(page.getByText('Total Companies')).toBeVisible();
   });
 

--- a/testing/e2e/crm-data.spec.ts
+++ b/testing/e2e/crm-data.spec.ts
@@ -35,7 +35,7 @@ test.describe('CRM flows (UI)', () => {
 
   test('dashboard metrics reflect seeded data', async ({ page }) => {
     await loginAsFounder(page);
-    await expect(page.getByRole('heading', { name: 'SDR Dashboard' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
     await expect(page.getByText('Total Companies')).toBeVisible();
     await expect(page.getByText('Total Contacts')).toBeVisible();
     // Seed creates 8 companies

--- a/testing/e2e/crm-flows.spec.ts
+++ b/testing/e2e/crm-flows.spec.ts
@@ -21,7 +21,7 @@ test.describe('Navigation (UI)', () => {
     await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible();
 
     await navTo(page, 'Dashboard');
-    await expect(page.getByRole('heading', { name: 'SDR Dashboard' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
   });
 
   test('SDR does not see admin-only nav', async ({ page }) => {

--- a/testing/e2e/helpers.ts
+++ b/testing/e2e/helpers.ts
@@ -31,7 +31,7 @@ export async function login(page: Page, email: string, password: string) {
 
 export async function loginAsFounder(page: Page) {
   await login(page, SEED.founder.email, SEED.founder.password);
-  await expect(page.getByRole('heading', { name: 'SDR Dashboard' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
 }
 
 export async function loginAsSdr(page: Page) {

--- a/testing/e2e/settings-champion-map.spec.ts
+++ b/testing/e2e/settings-champion-map.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import { loginAsFounder, navTo } from './helpers';
+
+test.describe('Settings champion status → stage map (issue #52)', () => {
+  test('founder can add, save, reload, and remove a mapping', async ({ page }) => {
+    await loginAsFounder(page);
+    await navTo(page, 'Settings');
+
+    const editor = page.getByTestId('champion-map-editor');
+    await expect(editor).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Champion status → pipeline stage' })
+    ).toBeVisible();
+    await expect(editor.getByText(/never move backward/i)).toBeVisible();
+
+    const statusValues = await editor
+      .getByLabel('Contact status', { exact: true })
+      .evaluateAll((els) => els.map((el) => (el as HTMLSelectElement).value));
+    expect(statusValues).toContain('Interested');
+
+    await page.getByTestId('champion-map-add').click();
+    const newRow = page.getByTestId('champion-map-row').last();
+    await newRow.getByLabel('Contact status', { exact: true }).selectOption('Not Contacted');
+    await newRow.getByLabel('Pipeline stage', { exact: true }).selectOption('Follow-up');
+
+    await page.getByRole('button', { name: 'Save settings' }).click();
+    await expect(
+      page.getByText('Settings saved. Pipeline and forms will use the new lists.')
+    ).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByText('Signed in as')).toBeVisible();
+    await navTo(page, 'Settings');
+    await expect(page.getByRole('heading', { name: 'Instance settings' })).toBeVisible();
+
+    const mappedRow = page.getByTestId('champion-map-row').filter({
+      has: page.getByLabel('Contact status', { exact: true }),
+    });
+    const rowCount = await mappedRow.count();
+    let notContactedRow = mappedRow.first();
+    let found = false;
+    for (let i = 0; i < rowCount; i++) {
+      const value = await mappedRow
+        .nth(i)
+        .getByLabel('Contact status', { exact: true })
+        .inputValue();
+      if (value === 'Not Contacted') {
+        notContactedRow = mappedRow.nth(i);
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+    await expect(notContactedRow.getByLabel('Pipeline stage', { exact: true })).toHaveValue(
+      'Follow-up'
+    );
+
+    await notContactedRow.getByTestId('champion-map-remove').click();
+    await page.getByRole('button', { name: 'Save settings' }).click();
+    await expect(
+      page.getByText('Settings saved. Pipeline and forms will use the new lists.')
+    ).toBeVisible();
+  });
+});

--- a/testing/functional/api/championStatusMap.test.ts
+++ b/testing/functional/api/championStatusMap.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { api, loginAs, SEED } from './helpers';
+
+type SettingsBody = {
+  championStatusToStage: Record<string, string | null>;
+  stages: string[];
+  contactStatuses: string[];
+  error?: string;
+};
+
+async function readMap(token: string) {
+  const res = await api<SettingsBody>('/api/config');
+  expect(res.status).toBe(200);
+  return {
+    token,
+    map: res.data.championStatusToStage,
+    stages: res.data.stages,
+    contactStatuses: res.data.contactStatuses,
+  };
+}
+
+describe('championStatusToStage settings', () => {
+  let restore: Record<string, string | null> | null = null;
+  let token = '';
+
+  afterEach(async () => {
+    if (restore && token) {
+      await api('/api/settings', {
+        method: 'PATCH',
+        token,
+        body: { championStatusToStage: restore },
+      });
+    }
+    restore = null;
+    token = '';
+  });
+
+  it('saves and reloads a valid mapping', async () => {
+    const auth = await loginAs(SEED.founder);
+    const current = await readMap(auth.token);
+    token = auth.token;
+    restore = current.map;
+
+    const next = {
+      ...current.map,
+      'Not Contacted': 'Follow-up',
+    };
+    const patched = await api<SettingsBody>('/api/settings', {
+      method: 'PATCH',
+      token,
+      body: { championStatusToStage: next },
+    });
+    expect(patched.status).toBe(200);
+    expect(patched.data.championStatusToStage['Not Contacted']).toBe('Follow-up');
+    expect(patched.data.championStatusToStage.Interested).toBe(current.map.Interested);
+
+    const reloaded = await api<SettingsBody>('/api/config');
+    expect(reloaded.status).toBe(200);
+    expect(reloaded.data.championStatusToStage['Not Contacted']).toBe('Follow-up');
+  });
+
+  it('rejects a status that is not in contactStatuses', async () => {
+    const auth = await loginAs(SEED.founder);
+    const current = await readMap(auth.token);
+    token = auth.token;
+    restore = current.map;
+
+    const res = await api<SettingsBody>('/api/settings', {
+      method: 'PATCH',
+      token,
+      body: { championStatusToStage: { Engaged: 'Follow-up' } },
+    });
+    expect(res.status).toBe(400);
+    expect(res.data.error).toContain('not a configured contact status');
+
+    const unchanged = await api<SettingsBody>('/api/config');
+    expect(unchanged.data.championStatusToStage).toEqual(current.map);
+  });
+
+  it('rejects a stage that is not in stages', async () => {
+    const auth = await loginAs(SEED.founder);
+    const current = await readMap(auth.token);
+    token = auth.token;
+    restore = current.map;
+
+    const res = await api<SettingsBody>('/api/settings', {
+      method: 'PATCH',
+      token,
+      body: { championStatusToStage: { Interested: 'Outreach Positive' } },
+    });
+    expect(res.status).toBe(400);
+    expect(res.data.error).toContain('unknown stage');
+
+    const unchanged = await api<SettingsBody>('/api/config');
+    expect(unchanged.data.championStatusToStage).toEqual(current.map);
+  });
+
+  it('rejects a non-object championStatusToStage payload', async () => {
+    const auth = await loginAs(SEED.founder);
+    token = auth.token;
+    const res = await api<SettingsBody>('/api/settings', {
+      method: 'PATCH',
+      token,
+      body: { championStatusToStage: ['Interested', 'Follow-up'] },
+    });
+    expect(res.status).toBe(400);
+    expect(res.data.error).toContain('object map');
+  });
+});

--- a/testing/unit/championStatusMap.test.ts
+++ b/testing/unit/championStatusMap.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_CONTACT_STATUSES, DEFAULT_STAGES } from '../../src/defaults';
+import {
+  championMapToRows,
+  championRowsToMap,
+  unusedContactStatuses,
+  validateChampionMapRows,
+  validateChampionStatusToStage,
+} from '../../src/lib/championStatusMap';
+
+const statuses = [...DEFAULT_CONTACT_STATUSES];
+const stages = [...DEFAULT_STAGES];
+
+describe('championMapToRows / championRowsToMap', () => {
+  it('drops null targets when building editor rows', () => {
+    const rows = championMapToRows({
+      Interested: 'Discovery Call Done',
+      'Not Contacted': null,
+      Called: 'Discovery Call Done',
+    });
+    expect(rows.map((r) => r.status)).toEqual(['Interested', 'Called']);
+    expect(championRowsToMap(rows)).toEqual({
+      Interested: 'Discovery Call Done',
+      Called: 'Discovery Call Done',
+    });
+  });
+});
+
+describe('validateChampionStatusToStage', () => {
+  it('accepts an empty map', () => {
+    expect(validateChampionStatusToStage({}, statuses, stages)).toBeNull();
+  });
+
+  it('accepts configured status/stage pairs and null targets', () => {
+    expect(
+      validateChampionStatusToStage(
+        { Interested: 'Discovery Call Done', 'Not Contacted': null },
+        statuses,
+        stages
+      )
+    ).toBeNull();
+  });
+
+  it('rejects a status that is not in the configured list', () => {
+    expect(validateChampionStatusToStage({ Engaged: 'Follow-up' }, statuses, stages)).toBe(
+      'championStatusToStage key "Engaged" is not a configured contact status.'
+    );
+  });
+
+  it('rejects a stage that is not in the configured list', () => {
+    expect(
+      validateChampionStatusToStage({ Interested: 'Outreach Positive' }, statuses, stages)
+    ).toBe('championStatusToStage["Interested"] targets unknown stage "Outreach Positive".');
+  });
+});
+
+describe('validateChampionMapRows', () => {
+  it('rejects duplicate statuses', () => {
+    expect(
+      validateChampionMapRows(
+        [
+          { id: 'a', status: 'Interested', stage: 'Follow-up' },
+          { id: 'b', status: 'Interested', stage: 'Discovery Call Done' },
+        ],
+        statuses,
+        stages
+      )
+    ).toBe('Contact status "Interested" is mapped more than once.');
+  });
+
+  it('rejects an empty status or stage', () => {
+    expect(
+      validateChampionMapRows([{ id: 'a', status: '', stage: 'Follow-up' }], statuses, stages)
+    ).toBe('Each mapping needs a contact status.');
+    expect(
+      validateChampionMapRows([{ id: 'a', status: 'Interested', stage: '' }], statuses, stages)
+    ).toBe('Each mapping needs a pipeline stage.');
+  });
+});
+
+describe('unusedContactStatuses', () => {
+  it('omits statuses already used on other rows', () => {
+    const rows = [{ id: 'a', status: 'Interested', stage: 'Follow-up' }];
+    expect(unusedContactStatuses(['Interested', 'Called'], rows)).toEqual(['Called']);
+    expect(unusedContactStatuses(['Interested', 'Called'], rows, 'Interested')).toEqual([
+      'Interested',
+      'Called',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Settings mapping editor so founders/admins can create, edit, and delete champion contact status → pipeline stage rows, saved through existing `PATCH /api/settings`.
- Harden API validation so keys must be configured contact statuses and values must be configured stages (or `null`); unknown pairs return a clear `400`.
- Document the UI in README / API docs, and align e2e login assertions with the `Dashboard` heading rename from #26.

Closes #52

## Tests
- [x] `npm test` (83 unit tests)
- [x] `npm run lint` + `npm run build`
- [x] `npm run test:api` (35 API tests, including save/load + invalid map rejection)
- [x] `npx playwright test` (36 e2e, including add/save/reload/remove mapping)

## Checklist
- [x] No secrets / PII
- [x] CI green


Made with [Cursor](https://cursor.com)