### PR TITLE
docs: tagged FastQA CTA on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ We needed:
 
 This repo is **Zero Cost CRM**: pipeline operations for founder-led sales teams.
 
-[ConvoBrains](https://www.convobrains.com) is the **intelligence layer**: conversation analysis for call quality, pitch effectiveness, and objection handling.
+[ConvoBrains](https://www.convobrains.com/?utm_source=github&utm_medium=readme&utm_campaign=india_inbound&utm_content=zero_cost_crm) is the **intelligence layer**: conversation analysis for call quality, pitch effectiveness, and objection handling.
+
+**Try FastQA (₹199 / $3.99 sample audit):** [Start AI call QA →](https://www.convobrains.com/onboarding?utm_source=github&utm_medium=readme&utm_campaign=india_inbound&utm_content=zero_cost_crm)
 
 > Zero Cost CRM tells you **what** happened.
 >


### PR DESCRIPTION
## Summary
- Tag ConvoBrains homepage link with GitHub README UTMs
- Add FastQA sample-audit CTA to `/onboarding` with the same campaign tags

## Why
India inbound Direct traffic is mostly untagged links. GitHub README should credit `utm_source=github` in PostHog.

## Test plan
- [ ] README renders on GitHub
- [ ] FastQA link opens `www.convobrains.com/onboarding` with expected query params


Made with [Cursor](https://cursor.com)