### PR TITLE
feat: add empty-state illustrations for Contacts and Pipeline (#69)

### DIFF
--- a/src/components/Contacts.tsx
+++ b/src/components/Contacts.tsx
@@ -12,7 +12,7 @@ import {
 } from '../lib/views';
 import { logViewEvent } from '../lib/activity';
 import { ContactForm } from './ContactForm';
-import { FilterChip, FilterDropdown, Modal, SearchInput, btnPrimary } from './ui';
+import { EmptyState, FilterChip, FilterDropdown, Modal, SearchInput, btnPrimary } from './ui';
 
 interface ContactsProps {
   store: CrmStore;
@@ -314,9 +314,9 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
           onClick={() => patchFilters({ championOnly: !filters.championOnly })}
           className={`shrink-0 rounded-none px-3 py-1.5 text-xs font-medium transition ${
             filters.championOnly
-              ? 'bg-teal-700 text-white'
-              : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
-          }`}
+            ? 'bg-teal-700 text-white'
+            : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
+            }`}
         >
           Champion only
         </button>
@@ -517,9 +517,16 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
           );
         })}
         {sorted.length === 0 ? (
-          <p className="py-10 text-center text-sm text-stone-400">
-            No contacts match these filters.
-          </p>
+          <EmptyState
+            title={filtersActive ? 'No contacts match these filters' : 'No contacts yet'}
+            message={
+              filtersActive
+                ? 'Try clearing a filter to see more results.'
+                : 'Add your first contact to start tracking follow-ups.'
+            }
+            ctaLabel={filtersActive ? 'Clear all filters' : '+ Add contact'}
+            onCta={filtersActive ? clearFilters : () => setCreating(true)}
+          />
         ) : null}
       </div>
 
@@ -627,8 +634,17 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
               })}
               {sorted.length === 0 ? (
                 <tr>
-                  <td colSpan={9} className="px-4 py-10 text-center text-sm text-stone-400">
-                    No contacts match these filters.
+                  <td colSpan={9} className="px-4 py-10">
+                    <EmptyState
+                      title={filtersActive ? 'No contacts match these filters' : 'No contacts yet'}
+                      message={
+                        filtersActive
+                          ? 'Try clearing a filter to see more results.'
+                          : 'Add your first contact to start tracking follow-ups.'
+                      }
+                      ctaLabel={filtersActive ? 'Clear all filters' : '+ Add contact'}
+                      onCta={filtersActive ? clearFilters : () => setCreating(true)}
+                    />
                   </td>
                 </tr>
               ) : null}

--- a/src/components/Contacts.tsx
+++ b/src/components/Contacts.tsx
@@ -314,9 +314,9 @@ export function Contacts({ store, contactStatuses, stages }: ContactsProps) {
           onClick={() => patchFilters({ championOnly: !filters.championOnly })}
           className={`shrink-0 rounded-none px-3 py-1.5 text-xs font-medium transition ${
             filters.championOnly
-            ? 'bg-teal-700 text-white'
-            : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
-            }`}
+              ? 'bg-teal-700 text-white'
+              : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
+          }`}
         >
           Champion only
         </button>

--- a/src/components/Pipeline.tsx
+++ b/src/components/Pipeline.tsx
@@ -29,7 +29,15 @@ import {
 import { buildCardBadges, buildChampionTrail, findChampion, istToday } from '../lib/championCard';
 import { logViewEvent } from '../lib/activity';
 import { CompanyForm } from './CompanyForm';
-import { EmptyState, FilterChip, FilterDropdown, Modal, SearchInput, btnPrimary, inputClass } from './ui';
+import {
+  EmptyState,
+  FilterChip,
+  FilterDropdown,
+  Modal,
+  SearchInput,
+  btnPrimary,
+  inputClass,
+} from './ui';
 
 interface PipelineProps {
   store: CrmStore;
@@ -73,7 +81,7 @@ function CompanyCard({
       data-company-id={company.id}
       className={`rounded-none border border-[var(--color-line)] bg-white p-3 text-left transition hover:border-teal-600/40 ${
         dragging ? 'opacity-40' : ''
-        }`}
+      }`}
     >
       <div className="flex items-start justify-between gap-2">
         <button
@@ -209,7 +217,7 @@ function KanbanColumn({
       ref={setNodeRef}
       className={`flex w-[min(72vw,16rem)] shrink-0 flex-col rounded-none border border-[var(--color-line)] border-t-4 bg-[var(--color-panel)]/70 sm:w-64 ${stageAccent(stage)} ${
         isOver ? 'ring-2 ring-teal-600/30' : ''
-        }`}
+      }`}
     >
       <div className="flex items-center justify-between px-3 py-2.5">
         <h3 className="text-xs font-semibold tracking-wide text-stone-700 uppercase">{stage}</h3>
@@ -447,7 +455,7 @@ export function Pipeline({
                     onClick={() => pickSuggestion(c)}
                     className={`flex w-full flex-col gap-0.5 px-3 py-2 text-left text-xs transition ${
                       i === highlight ? 'bg-teal-50' : 'hover:bg-stone-50'
-                      }`}
+                    }`}
                   >
                     <span className="font-medium text-stone-900">{c.companyName}</span>
                     <span className="text-stone-500">
@@ -517,9 +525,9 @@ export function Pipeline({
           <FilterChip
             label={`Added: ${dateLabel}${
               filters.dateRange === 'custom'
-              ? ` ${filters.customFrom ?? '…'} → ${filters.customTo ?? '…'}`
-              : ''
-              }`}
+                ? ` ${filters.customFrom ?? '…'} → ${filters.customTo ?? '…'}`
+                : ''
+            }`}
             onClear={() => setFilters(DEFAULT_PIPELINE_FILTERS)}
           />
           <button
@@ -541,9 +549,9 @@ export function Pipeline({
             onClick={() => setView(v)}
             className={`shrink-0 rounded-none px-3 py-1.5 text-xs font-medium transition ${
               view === v
-              ? 'bg-teal-700 text-white'
-              : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
-              }`}
+                ? 'bg-teal-700 text-white'
+                : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
+            }`}
           >
             {v}
             <span className="ml-1.5 opacity-70">({viewCounts.get(v) ?? 0})</span>
@@ -657,7 +665,6 @@ export function Pipeline({
           </div>
         ) : null}
       </section>
-
 
       {filtered.length === 0 ? (
         <EmptyState

--- a/src/components/Pipeline.tsx
+++ b/src/components/Pipeline.tsx
@@ -29,7 +29,7 @@ import {
 import { buildCardBadges, buildChampionTrail, findChampion, istToday } from '../lib/championCard';
 import { logViewEvent } from '../lib/activity';
 import { CompanyForm } from './CompanyForm';
-import { FilterChip, FilterDropdown, Modal, SearchInput, btnPrimary, inputClass } from './ui';
+import { EmptyState, FilterChip, FilterDropdown, Modal, SearchInput, btnPrimary, inputClass } from './ui';
 
 interface PipelineProps {
   store: CrmStore;
@@ -73,7 +73,7 @@ function CompanyCard({
       data-company-id={company.id}
       className={`rounded-none border border-[var(--color-line)] bg-white p-3 text-left transition hover:border-teal-600/40 ${
         dragging ? 'opacity-40' : ''
-      }`}
+        }`}
     >
       <div className="flex items-start justify-between gap-2">
         <button
@@ -209,7 +209,7 @@ function KanbanColumn({
       ref={setNodeRef}
       className={`flex w-[min(72vw,16rem)] shrink-0 flex-col rounded-none border border-[var(--color-line)] border-t-4 bg-[var(--color-panel)]/70 sm:w-64 ${stageAccent(stage)} ${
         isOver ? 'ring-2 ring-teal-600/30' : ''
-      }`}
+        }`}
     >
       <div className="flex items-center justify-between px-3 py-2.5">
         <h3 className="text-xs font-semibold tracking-wide text-stone-700 uppercase">{stage}</h3>
@@ -447,7 +447,7 @@ export function Pipeline({
                     onClick={() => pickSuggestion(c)}
                     className={`flex w-full flex-col gap-0.5 px-3 py-2 text-left text-xs transition ${
                       i === highlight ? 'bg-teal-50' : 'hover:bg-stone-50'
-                    }`}
+                      }`}
                   >
                     <span className="font-medium text-stone-900">{c.companyName}</span>
                     <span className="text-stone-500">
@@ -517,9 +517,9 @@ export function Pipeline({
           <FilterChip
             label={`Added: ${dateLabel}${
               filters.dateRange === 'custom'
-                ? ` ${filters.customFrom ?? '…'} → ${filters.customTo ?? '…'}`
-                : ''
-            }`}
+              ? ` ${filters.customFrom ?? '…'} → ${filters.customTo ?? '…'}`
+              : ''
+              }`}
             onClear={() => setFilters(DEFAULT_PIPELINE_FILTERS)}
           />
           <button
@@ -541,9 +541,9 @@ export function Pipeline({
             onClick={() => setView(v)}
             className={`shrink-0 rounded-none px-3 py-1.5 text-xs font-medium transition ${
               view === v
-                ? 'bg-teal-700 text-white'
-                : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
-            }`}
+              ? 'bg-teal-700 text-white'
+              : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
+              }`}
           >
             {v}
             <span className="ml-1.5 opacity-70">({viewCounts.get(v) ?? 0})</span>
@@ -658,32 +658,50 @@ export function Pipeline({
         ) : null}
       </section>
 
-      <DndContext
-        sensors={sensors}
-        collisionDetection={rectIntersection}
-        onDragStart={onDragStart}
-        onDragEnd={onDragEnd}
-      >
-        <div className="flex min-h-0 flex-1 gap-3 overflow-x-auto pb-2 kanban-scroll">
-          {boardStages.map((stage) => (
-            <KanbanColumn
-              key={stage}
-              stage={stage}
-              companies={byStage.get(stage) ?? []}
-              store={store}
-              today={today}
-              onOpen={openCompany}
-            />
-          ))}
-        </div>
-        <DragOverlay>
-          {activeCompany ? (
-            <div className="w-[min(72vw,16rem)] rotate-1 sm:w-64">
-              <CompanyCard company={activeCompany} contacts={store.contacts} today={today} />
-            </div>
-          ) : null}
-        </DragOverlay>
-      </DndContext>
+
+      {filtered.length === 0 ? (
+        <EmptyState
+          title={filtersActive ? 'No companies match these filters' : 'No companies yet'}
+          message={
+            filtersActive
+              ? 'Try clearing a filter to see more companies.'
+              : 'Add your first company to start building your pipeline.'
+          }
+          ctaLabel={filtersActive ? 'Clear date filter' : '+ Add company'}
+          onCta={
+            filtersActive ? () => setFilters(DEFAULT_PIPELINE_FILTERS) : () => setCreating(true)
+          }
+        />
+      ) : null}
+
+      {filtered.length > 0 ? (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={rectIntersection}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+        >
+          <div className="flex min-h-0 flex-1 gap-3 overflow-x-auto pb-2 kanban-scroll">
+            {boardStages.map((stage) => (
+              <KanbanColumn
+                key={stage}
+                stage={stage}
+                companies={byStage.get(stage) ?? []}
+                store={store}
+                today={today}
+                onOpen={openCompany}
+              />
+            ))}
+          </div>
+          <DragOverlay>
+            {activeCompany ? (
+              <div className="w-[min(72vw,16rem)] rotate-1 sm:w-64">
+                <CompanyCard company={activeCompany} contacts={store.contacts} today={today} />
+              </div>
+            ) : null}
+          </DragOverlay>
+        </DndContext>
+      ) : null}
 
       <Modal open={creating} title="Add company" onClose={() => setCreating(false)} wide>
         <CompanyForm

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -40,7 +40,7 @@ export function Modal({ open, title, onClose, children, wide }: ModalProps) {
         aria-labelledby={titleId}
         className={`relative z-10 my-0 w-full rounded-none border border-[var(--color-line)] bg-[var(--color-panel)] sm:my-4 ${
           wide ? 'max-w-3xl' : 'max-w-xl'
-          }`}
+        }`}
       >
         <div className="flex items-center justify-between border-b border-[var(--color-line)] px-4 py-3 sm:px-5 sm:py-4">
           <h2
@@ -253,62 +253,62 @@ export function FilterDropdown({
   const panel =
     open && typeof document !== 'undefined'
       ? createPortal(
-        <div
-          ref={panelRef}
-          role="listbox"
-          data-testid={testId ? `${testId}-panel` : undefined}
-          aria-multiselectable={multi || undefined}
-          style={panelStyle}
-          className="overflow-auto border border-[var(--color-line)] bg-white shadow-lg"
-        >
-          {searchable ? (
-            <div className="sticky top-0 border-b border-[var(--color-line)] bg-white p-2">
-              <input
-                type="search"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search…"
-                className={`${inputClass} py-1.5 text-xs`}
-                autoFocus
-              />
-            </div>
-          ) : null}
-          {filtered.length === 0 ? (
-            <p className="px-3 py-2 text-xs text-stone-400">No matches</p>
-          ) : (
-            filtered.map((opt) => {
-              const isOn = selected.includes(opt.value);
-              return (
-                <button
-                  key={opt.value || '__all__'}
-                  type="button"
-                  role="option"
-                  aria-selected={isOn}
-                  onClick={() => toggle(opt.value)}
+          <div
+            ref={panelRef}
+            role="listbox"
+            data-testid={testId ? `${testId}-panel` : undefined}
+            aria-multiselectable={multi || undefined}
+            style={panelStyle}
+            className="overflow-auto border border-[var(--color-line)] bg-white shadow-lg"
+          >
+            {searchable ? (
+              <div className="sticky top-0 border-b border-[var(--color-line)] bg-white p-2">
+                <input
+                  type="search"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search…"
+                  className={`${inputClass} py-1.5 text-xs`}
+                  autoFocus
+                />
+              </div>
+            ) : null}
+            {filtered.length === 0 ? (
+              <p className="px-3 py-2 text-xs text-stone-400">No matches</p>
+            ) : (
+              filtered.map((opt) => {
+                const isOn = selected.includes(opt.value);
+                return (
+                  <button
+                    key={opt.value || '__all__'}
+                    type="button"
+                    role="option"
+                    aria-selected={isOn}
+                    onClick={() => toggle(opt.value)}
                     className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition hover:bg-teal-50 ${
                       isOn ? 'bg-teal-50/80 font-medium text-teal-900' : 'text-stone-700'
                     }`}
-                >
-                  {multi ? (
-                    <span
-                      aria-hidden
+                  >
+                    {multi ? (
+                      <span
+                        aria-hidden
                         className={`inline-flex h-3.5 w-3.5 items-center justify-center border text-[9px] ${
                           isOn
-                        ? 'border-teal-700 bg-teal-700 text-white'
-                        : 'border-stone-300 bg-white'
+                            ? 'border-teal-700 bg-teal-700 text-white'
+                            : 'border-stone-300 bg-white'
                         }`}
-                    >
-                      {isOn ? '✓' : ''}
-                    </span>
-                  ) : null}
-                  <span className="min-w-0 truncate">{opt.label}</span>
-                </button>
-              );
-            })
-          )}
-        </div>,
-        document.body
-      )
+                      >
+                        {isOn ? '✓' : ''}
+                      </span>
+                    ) : null}
+                    <span className="min-w-0 truncate">{opt.label}</span>
+                  </button>
+                );
+              })
+            )}
+          </div>,
+          document.body
+        )
       : null;
 
   return (
@@ -326,9 +326,9 @@ export function FilterDropdown({
         }}
         className={`inline-flex items-center gap-1.5 rounded-none px-3 py-1.5 text-xs font-medium transition ${
           active
-          ? 'bg-teal-700 text-white'
-          : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
-          }`}
+            ? 'bg-teal-700 text-white'
+            : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
+        }`}
       >
         <span className="opacity-70">{label}:</span>
         <span>{summary}</span>
@@ -362,14 +362,13 @@ export function FilterChip({ label, onClear }: FilterChipProps) {
   );
 }
 
-
 // EmptyState: shown instead of a blank table/board when there's nothing to display.
 // Reusable everywhere so every "no data" screen looks and behaves the same way.
 interface EmptyStateProps {
-  title: string;       // short headline, e.g. "No companies yet"
-  message: string;      // one sentence explaining what to do next
-  ctaLabel: string;     // button text, e.g. "+ Add company"
-  onCta: () => void;    // function to run when button is clicked
+  title: string; // short headline, e.g. "No companies yet"
+  message: string; // one sentence explaining what to do next
+  ctaLabel: string; // button text, e.g. "+ Add company"
+  onCta: () => void; // function to run when button is clicked
 }
 
 export function EmptyState({ title, message, ctaLabel, onCta }: EmptyStateProps) {

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -40,7 +40,7 @@ export function Modal({ open, title, onClose, children, wide }: ModalProps) {
         aria-labelledby={titleId}
         className={`relative z-10 my-0 w-full rounded-none border border-[var(--color-line)] bg-[var(--color-panel)] sm:my-4 ${
           wide ? 'max-w-3xl' : 'max-w-xl'
-        }`}
+          }`}
       >
         <div className="flex items-center justify-between border-b border-[var(--color-line)] px-4 py-3 sm:px-5 sm:py-4">
           <h2
@@ -253,62 +253,62 @@ export function FilterDropdown({
   const panel =
     open && typeof document !== 'undefined'
       ? createPortal(
-          <div
-            ref={panelRef}
-            role="listbox"
-            data-testid={testId ? `${testId}-panel` : undefined}
-            aria-multiselectable={multi || undefined}
-            style={panelStyle}
-            className="overflow-auto border border-[var(--color-line)] bg-white shadow-lg"
-          >
-            {searchable ? (
-              <div className="sticky top-0 border-b border-[var(--color-line)] bg-white p-2">
-                <input
-                  type="search"
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  placeholder="Search…"
-                  className={`${inputClass} py-1.5 text-xs`}
-                  autoFocus
-                />
-              </div>
-            ) : null}
-            {filtered.length === 0 ? (
-              <p className="px-3 py-2 text-xs text-stone-400">No matches</p>
-            ) : (
-              filtered.map((opt) => {
-                const isOn = selected.includes(opt.value);
-                return (
-                  <button
-                    key={opt.value || '__all__'}
-                    type="button"
-                    role="option"
-                    aria-selected={isOn}
-                    onClick={() => toggle(opt.value)}
+        <div
+          ref={panelRef}
+          role="listbox"
+          data-testid={testId ? `${testId}-panel` : undefined}
+          aria-multiselectable={multi || undefined}
+          style={panelStyle}
+          className="overflow-auto border border-[var(--color-line)] bg-white shadow-lg"
+        >
+          {searchable ? (
+            <div className="sticky top-0 border-b border-[var(--color-line)] bg-white p-2">
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search…"
+                className={`${inputClass} py-1.5 text-xs`}
+                autoFocus
+              />
+            </div>
+          ) : null}
+          {filtered.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-stone-400">No matches</p>
+          ) : (
+            filtered.map((opt) => {
+              const isOn = selected.includes(opt.value);
+              return (
+                <button
+                  key={opt.value || '__all__'}
+                  type="button"
+                  role="option"
+                  aria-selected={isOn}
+                  onClick={() => toggle(opt.value)}
                     className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition hover:bg-teal-50 ${
                       isOn ? 'bg-teal-50/80 font-medium text-teal-900' : 'text-stone-700'
                     }`}
-                  >
-                    {multi ? (
-                      <span
-                        aria-hidden
+                >
+                  {multi ? (
+                    <span
+                      aria-hidden
                         className={`inline-flex h-3.5 w-3.5 items-center justify-center border text-[9px] ${
                           isOn
-                            ? 'border-teal-700 bg-teal-700 text-white'
-                            : 'border-stone-300 bg-white'
+                        ? 'border-teal-700 bg-teal-700 text-white'
+                        : 'border-stone-300 bg-white'
                         }`}
-                      >
-                        {isOn ? '✓' : ''}
-                      </span>
-                    ) : null}
-                    <span className="min-w-0 truncate">{opt.label}</span>
-                  </button>
-                );
-              })
-            )}
-          </div>,
-          document.body
-        )
+                    >
+                      {isOn ? '✓' : ''}
+                    </span>
+                  ) : null}
+                  <span className="min-w-0 truncate">{opt.label}</span>
+                </button>
+              );
+            })
+          )}
+        </div>,
+        document.body
+      )
       : null;
 
   return (
@@ -326,9 +326,9 @@ export function FilterDropdown({
         }}
         className={`inline-flex items-center gap-1.5 rounded-none px-3 py-1.5 text-xs font-medium transition ${
           active
-            ? 'bg-teal-700 text-white'
-            : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
-        }`}
+          ? 'bg-teal-700 text-white'
+          : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
+          }`}
       >
         <span className="opacity-70">{label}:</span>
         <span>{summary}</span>
@@ -359,5 +359,27 @@ export function FilterChip({ label, onClear }: FilterChipProps) {
         ×
       </button>
     </span>
+  );
+}
+
+
+// EmptyState: shown instead of a blank table/board when there's nothing to display.
+// Reusable everywhere so every "no data" screen looks and behaves the same way.
+interface EmptyStateProps {
+  title: string;       // short headline, e.g. "No companies yet"
+  message: string;      // one sentence explaining what to do next
+  ctaLabel: string;     // button text, e.g. "+ Add company"
+  onCta: () => void;    // function to run when button is clicked
+}
+
+export function EmptyState({ title, message, ctaLabel, onCta }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 rounded-none border border-dashed border-line bg-panel px-4 py-12 text-center">
+      <p className="font-display text-xl text-stone-800">{title}</p>
+      <p className="max-w-sm text-sm text-stone-500">{message}</p>
+      <button type="button" className={btnPrimary} onClick={onCta}>
+        {ctaLabel}
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #69

Adds a reusable `EmptyState` component (in `src/components/ui.tsx`) and uses it to replace the plain "no results" text with a headline, one-line message, and a working CTA button:

- **Contacts** — mobile card view and desktop table view, for both "no data yet" and "filtered to zero" cases
- **Pipeline** — replaces the whole Kanban board with a single empty state when there are zero companies (or filtered to zero), instead of showing empty columns

No new npm dependencies. Matches the existing teal/stone palette and button styles already used elsewhere in the app.

## Tests

- [x] `npm test` (and `npm run test:api` / `make test-e2e` if API/UI flows changed)
- [ ] New/updated tests for this change (or docs-only)

## Checklist

- [x] No secrets / PII
- [x] CI green