### PR TITLE
fix: distinguish filtered-empty from truly-empty pipeline view

### DIFF
--- a/src/components/Pipeline.tsx
+++ b/src/components/Pipeline.tsx
@@ -79,9 +79,8 @@ function CompanyCard({
     <div
       data-testid="company-card"
       data-company-id={company.id}
-      className={`rounded-none border border-[var(--color-line)] bg-white p-3 text-left transition hover:border-teal-600/40 ${
-        dragging ? 'opacity-40' : ''
-      }`}
+      className={`rounded-none border border-[var(--color-line)] bg-white p-3 text-left transition hover:border-teal-600/40 ${dragging ? 'opacity-40' : ''
+        }`}
     >
       <div className="flex items-start justify-between gap-2">
         <button
@@ -215,9 +214,8 @@ function KanbanColumn({
   return (
     <div
       ref={setNodeRef}
-      className={`flex w-[min(72vw,16rem)] shrink-0 flex-col rounded-none border border-[var(--color-line)] border-t-4 bg-[var(--color-panel)]/70 sm:w-64 ${stageAccent(stage)} ${
-        isOver ? 'ring-2 ring-teal-600/30' : ''
-      }`}
+      className={`flex w-[min(72vw,16rem)] shrink-0 flex-col rounded-none border border-[var(--color-line)] border-t-4 bg-[var(--color-panel)]/70 sm:w-64 ${stageAccent(stage)} ${isOver ? 'ring-2 ring-teal-600/30' : ''
+        }`}
     >
       <div className="flex items-center justify-between px-3 py-2.5">
         <h3 className="text-xs font-semibold tracking-wide text-stone-700 uppercase">{stage}</h3>
@@ -354,6 +352,7 @@ export function Pipeline({
 
   const today = istToday();
   const filtersActive = pipelineFiltersAreActive(filters);
+  const isNarrowedDown = filtersActive || view !== 'All Companies';
   const dateLabel =
     PIPELINE_DATE_RANGE_OPTIONS.find((o) => o.value === filters.dateRange)?.label ?? 'All Time';
 
@@ -453,9 +452,8 @@ export function Pipeline({
                     data-testid="pipeline-search-suggestion"
                     onMouseEnter={() => setHighlight(i)}
                     onClick={() => pickSuggestion(c)}
-                    className={`flex w-full flex-col gap-0.5 px-3 py-2 text-left text-xs transition ${
-                      i === highlight ? 'bg-teal-50' : 'hover:bg-stone-50'
-                    }`}
+                    className={`flex w-full flex-col gap-0.5 px-3 py-2 text-left text-xs transition ${i === highlight ? 'bg-teal-50' : 'hover:bg-stone-50'
+                      }`}
                   >
                     <span className="font-medium text-stone-900">{c.companyName}</span>
                     <span className="text-stone-500">
@@ -523,11 +521,10 @@ export function Pipeline({
       {filtersActive ? (
         <div className="flex flex-wrap items-center gap-2">
           <FilterChip
-            label={`Added: ${dateLabel}${
-              filters.dateRange === 'custom'
+            label={`Added: ${dateLabel}${filters.dateRange === 'custom'
                 ? ` ${filters.customFrom ?? '…'} → ${filters.customTo ?? '…'}`
                 : ''
-            }`}
+              }`}
             onClear={() => setFilters(DEFAULT_PIPELINE_FILTERS)}
           />
           <button
@@ -547,11 +544,10 @@ export function Pipeline({
             key={v}
             type="button"
             onClick={() => setView(v)}
-            className={`shrink-0 rounded-none px-3 py-1.5 text-xs font-medium transition ${
-              view === v
+            className={`shrink-0 rounded-none px-3 py-1.5 text-xs font-medium transition ${view === v
                 ? 'bg-teal-700 text-white'
                 : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
-            }`}
+              }`}
           >
             {v}
             <span className="ml-1.5 opacity-70">({viewCounts.get(v) ?? 0})</span>
@@ -668,15 +664,20 @@ export function Pipeline({
 
       {filtered.length === 0 ? (
         <EmptyState
-          title={filtersActive ? 'No companies match these filters' : 'No companies yet'}
+          title={isNarrowedDown ? 'No companies match this view' : 'No companies yet'}
           message={
-            filtersActive
-              ? 'Try clearing a filter to see more companies.'
+            isNarrowedDown
+              ? 'Try a different view or clear the date filter to see more companies.'
               : 'Add your first company to start building your pipeline.'
           }
-          ctaLabel={filtersActive ? 'Clear date filter' : '+ Add company'}
+          ctaLabel={isNarrowedDown ? 'Show all companies' : '+ Add company'}
           onCta={
-            filtersActive ? () => setFilters(DEFAULT_PIPELINE_FILTERS) : () => setCreating(true)
+            isNarrowedDown
+              ? () => {
+                setView('All Companies');
+                setFilters(DEFAULT_PIPELINE_FILTERS);
+              }
+              : () => setCreating(true)
           }
         />
       ) : null}

--- a/src/components/Pipeline.tsx
+++ b/src/components/Pipeline.tsx
@@ -79,8 +79,9 @@ function CompanyCard({
     <div
       data-testid="company-card"
       data-company-id={company.id}
-      className={`rounded-none border border-[var(--color-line)] bg-white p-3 text-left transition hover:border-teal-600/40 ${dragging ? 'opacity-40' : ''
-        }`}
+      className={`rounded-none border border-[var(--color-line)] bg-white p-3 text-left transition hover:border-teal-600/40 ${
+        dragging ? 'opacity-40' : ''
+      }`}
     >
       <div className="flex items-start justify-between gap-2">
         <button
@@ -214,8 +215,9 @@ function KanbanColumn({
   return (
     <div
       ref={setNodeRef}
-      className={`flex w-[min(72vw,16rem)] shrink-0 flex-col rounded-none border border-[var(--color-line)] border-t-4 bg-[var(--color-panel)]/70 sm:w-64 ${stageAccent(stage)} ${isOver ? 'ring-2 ring-teal-600/30' : ''
-        }`}
+      className={`flex w-[min(72vw,16rem)] shrink-0 flex-col rounded-none border border-[var(--color-line)] border-t-4 bg-[var(--color-panel)]/70 sm:w-64 ${stageAccent(stage)} ${
+        isOver ? 'ring-2 ring-teal-600/30' : ''
+      }`}
     >
       <div className="flex items-center justify-between px-3 py-2.5">
         <h3 className="text-xs font-semibold tracking-wide text-stone-700 uppercase">{stage}</h3>
@@ -452,8 +454,9 @@ export function Pipeline({
                     data-testid="pipeline-search-suggestion"
                     onMouseEnter={() => setHighlight(i)}
                     onClick={() => pickSuggestion(c)}
-                    className={`flex w-full flex-col gap-0.5 px-3 py-2 text-left text-xs transition ${i === highlight ? 'bg-teal-50' : 'hover:bg-stone-50'
-                      }`}
+                    className={`flex w-full flex-col gap-0.5 px-3 py-2 text-left text-xs transition ${
+                      i === highlight ? 'bg-teal-50' : 'hover:bg-stone-50'
+                    }`}
                   >
                     <span className="font-medium text-stone-900">{c.companyName}</span>
                     <span className="text-stone-500">
@@ -521,10 +524,11 @@ export function Pipeline({
       {filtersActive ? (
         <div className="flex flex-wrap items-center gap-2">
           <FilterChip
-            label={`Added: ${dateLabel}${filters.dateRange === 'custom'
+            label={`Added: ${dateLabel}${
+              filters.dateRange === 'custom'
                 ? ` ${filters.customFrom ?? '…'} → ${filters.customTo ?? '…'}`
                 : ''
-              }`}
+            }`}
             onClear={() => setFilters(DEFAULT_PIPELINE_FILTERS)}
           />
           <button
@@ -544,10 +548,11 @@ export function Pipeline({
             key={v}
             type="button"
             onClick={() => setView(v)}
-            className={`shrink-0 rounded-none px-3 py-1.5 text-xs font-medium transition ${view === v
+            className={`shrink-0 rounded-none px-3 py-1.5 text-xs font-medium transition ${
+              view === v
                 ? 'bg-teal-700 text-white'
                 : 'bg-white text-stone-600 ring-1 ring-[var(--color-line)] hover:bg-stone-50'
-              }`}
+            }`}
           >
             {v}
             <span className="ml-1.5 opacity-70">({viewCounts.get(v) ?? 0})</span>
@@ -674,9 +679,9 @@ export function Pipeline({
           onCta={
             isNarrowedDown
               ? () => {
-                setView('All Companies');
-                setFilters(DEFAULT_PIPELINE_FILTERS);
-              }
+                  setView('All Companies');
+                  setFilters(DEFAULT_PIPELINE_FILTERS);
+                }
               : () => setCreating(true)
           }
         />


### PR DESCRIPTION
## Summary

Follow-up to #91 / #69.

@Rajsaura found that selecting a Pipeline view (e.g. "Demo Delivered") with 0 matching companies incorrectly showed the "No companies yet" first-run empty state, even when the database has companies in other stages.

Fixes this by also checking the selected view (not just the date filter) to decide between "No companies yet" and "No companies match this view" — and resets both the view and filters when the CTA is clicked.

## Tests

- [x] Manually verified: selecting a 0-count view now shows the correct filtered-empty message and CTA
- [ ] New/updated tests for this change

## Checklist

- [x] No secrets / PII
- [x] CI green